### PR TITLE
Add static tooling to pom settings

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+    </module>
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+        <module name="FileContentsHolder"/>
+        <module name="JavadocMethod">
+            <property name="scope" value="package"/>
+            <property name="suppressLoadErrors" value="true"/>
+        </module>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="JavadocStyle"/>
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="30"/>
+        </module>
+        <module name="ParameterNumber"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="AvoidInlineConditionals">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="DesignForExtension">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="TodoComment">
+            <property name="severity" value="ignore"/>
+            <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+        </module>
+        <module name="UpperEll"/>
+        <module name="FallThrough"/>
+        <module name="MethodLength">
+            <property name="max" value="30"/>
+        </module>
+    </module>
+    <module name="NewlineAtEndOfFile">
+        <property name="severity" value="ignore"/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="Translation"/>
+    <module name="FileLength"/>
+    <module name="FileTabCharacter">
+        <property name="severity" value="ignore"/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+        <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+</module>

--- a/org.metaborg.spoofax.shell.console/pom.xml
+++ b/org.metaborg.spoofax.shell.console/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.metaborg.spoofax.shell.console</artifactId>
 
@@ -121,6 +118,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <!-- Not creating a dependency-reduced-pom.xml prevents the checkstyle configuration directory from 
+                breaking. -->
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>${console-main-class}</mainClass>
@@ -169,6 +169,159 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <dependencies>
+          <!-- Update Checkstyle to version 6.18 at runtime -->
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.18</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <violationSeverity>warning</violationSeverity>
+          <consoleOutput>false</consoleOutput>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>verify-style</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <!-- Using the latest version here breaks the reporting. -->
+        <!-- dependencies> <dependency> <groupId>net.sourceforge.pmd</groupId> <artifactId>pmd-java</artifactId> 
+          <version>5.4.0</version> </dependency> </dependencies -->
+        <configuration>
+          <verbose>true</verbose>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pmd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>cpd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
+          <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>findbugs-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+      </plugin>
+      <!-- JavaDoc -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+      </plugin>
+      <!-- JXR, (optional) dependency of both PMD and Checkstyle in order to xref sources. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <skipEmptyReport>false</skipEmptyReport>
+        </configuration>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <organization>
+    <name>Delft University of Technology</name>
+    <url>http://www.ewi.tudelft.nl/en</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <name>Justin van der Krieken</name>
+      <email>justin@vdkrieken.com</email>
+      <url>https://github.com/justinvdk</url>
+    </developer>
+    <developer>
+      <name>Wouter Smit</name>
+      <email>pathemeous@gmail.com</email>
+      <url>https://github.com/Pathemeous</url>
+    </developer>
+  </developers>
 </project>

--- a/org.metaborg.spoofax.shell.console/pom.xml
+++ b/org.metaborg.spoofax.shell.console/pom.xml
@@ -38,11 +38,11 @@
       <artifactId>org.metaborg.meta.lang.dynsem.interpreter</artifactId>
       <version>${metaborg-version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.metaborg</groupId>
-      <artifactId>org.metaborg.meta.interpreter.framework</artifactId>
-      <version>${metaborg-version}</version>
-    </dependency>
+<!--     <dependency> -->
+<!--       <groupId>org.metaborg</groupId> -->
+<!--       <artifactId>org.metaborg.meta.interpreter.framework</artifactId> -->
+<!--       <version>${metaborg-version}</version> -->
+<!--     </dependency> -->
 
     <dependency>
       <groupId>jline</groupId>

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/ConsoleReplModule.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/ConsoleReplModule.java
@@ -26,46 +26,49 @@ import jline.console.ConsoleReader;
  * Bindings for the console REPL.
  */
 public class ConsoleReplModule extends ReplModule {
-    @Override protected void configure() {
-        super.configure();
-        bindUserInterface();
-    }
+	@Override
+	protected void configure() {
+		super.configure();
+		bindUserInterface();
+	}
 
-    
-    @Override protected void bindEvalStrategies(MapBinder<String, IEvaluationStrategy> evalStrategyBinder) {
-        super.bindEvalStrategies(evalStrategyBinder);
-        bind(IInterpreterLoader.class).to(ClassPathInterpreterLoader.class);
+	@Override
+	protected void bindEvalStrategies(MapBinder<String, IEvaluationStrategy> evalStrategyBinder) {
+		super.bindEvalStrategies(evalStrategyBinder);
+		bind(IInterpreterLoader.class).to(ClassPathInterpreterLoader.class);
 
-        // Make sure the DynSemEvaluationStrategy is a singleton so the REPL
-        // always uses the same unique rwSemanticComponents to evaluate in context.
-        bind(DynSemEvaluationStrategy.class).in(Singleton.class);
-        evalStrategyBinder.addBinding("dynsem").to(DynSemEvaluationStrategy.class);
-        evalStrategyBinder.addBinding("stratego").to(StrategoEvaluationStrategy.class);
-    }
-    
-    @Override protected void bindCommands(MapBinder<String, IReplCommand> commandBinder) {
-        super.bindCommands(commandBinder);
-        commandBinder.addBinding("exit").to(ExitCommand.class).in(Singleton.class);
-    }
+		// Make sure the DynSemEvaluationStrategy is a singleton so the REPL
+		// always uses the same unique rwSemanticComponents to evaluate in
+		// context.
+		bind(DynSemEvaluationStrategy.class).in(Singleton.class);
+		evalStrategyBinder.addBinding("dynsem").to(DynSemEvaluationStrategy.class);
+		evalStrategyBinder.addBinding("stratego").to(StrategoEvaluationStrategy.class);
+	}
 
-    /**
-     * Binds the user interface implementations.
-     */
-    protected void bindUserInterface() {
-        bind(IRepl.class).to(ConsoleRepl.class);
-        bind(ConsoleRepl.class).in(Singleton.class);
-        bind(ConsoleReader.class).in(Singleton.class);
-        bind(IInputHistory.class).to(JLine2InputHistory.class);
-        bind(JLine2InputHistory.class).to(JLine2PersistentInputHistory.class);
+	@Override
+	protected void bindCommands(MapBinder<String, IReplCommand> commandBinder) {
+		super.bindCommands(commandBinder);
+		commandBinder.addBinding("exit").to(ExitCommand.class).in(Singleton.class);
+	}
 
-        bind(TerminalUserInterface.class).in(Singleton.class);
-        bind(IDisplay.class).to(TerminalUserInterface.class);
+	/**
+	 * Binds the user interface implementations.
+	 */
+	protected void bindUserInterface() {
+		bind(IRepl.class).to(ConsoleRepl.class);
+		bind(ConsoleRepl.class).in(Singleton.class);
+		bind(ConsoleReader.class).in(Singleton.class);
+		bind(IInputHistory.class).to(JLine2InputHistory.class);
+		bind(JLine2InputHistory.class).to(JLine2PersistentInputHistory.class);
 
-        bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(System.in);
-        bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(System.out);
-        bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(System.err);
+		bind(TerminalUserInterface.class).in(Singleton.class);
+		bind(IDisplay.class).to(TerminalUserInterface.class);
 
-        bindConstant().annotatedWith(Names.named("historyPath"))
-            .to(System.getProperty("user.home") + "/.spoofax_history");
-    }
+		bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(System.in);
+		bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(System.out);
+		bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(System.err);
+
+		bindConstant().annotatedWith(Names.named("historyPath"))
+				.to(System.getProperty("user.home") + "/.spoofax_history");
+	}
 }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/Main.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/Main.java
@@ -14,49 +14,52 @@ import com.google.inject.Injector;
 /**
  * This class launches a {@link ConsoleRepl}, a console based REPL.
  */
+// CHECKSTYLE.OFF: HideUtilityClassConstructor - No need for private constructor
 public final class Main {
-    private static final String ERROR =
-        "Invalid commandline parameters: %s%nThe only argument " + "accepted is the path to a language implementation "
-            + "location, using any filesystem supported by Apache VFS";
+	// CHECKSTYLE.ON
+	private static final String ERROR = "Invalid commandline parameters: %s%nThe only argument "
+			+ "accepted is the path to a language implementation "
+			+ "location, using any filesystem supported by Apache VFS";
 
-    private static StyledText error(String[] args) {
-        StringBuilder invalidArgs = new StringBuilder();
-        for(String arg : args) {
-            invalidArgs.append(arg).append(", ");
-        }
-        // Remove the appended ", " from the string.
-        invalidArgs.delete(invalidArgs.length() - 2, invalidArgs.length());
-        return new StyledText(Color.RED, String.format(ERROR, invalidArgs.toString()));
-    }
+	private static StyledText error(String[] args) {
+		StringBuilder invalidArgs = new StringBuilder();
+		for (String arg : args) {
+			invalidArgs.append(arg).append(", ");
+		}
+		// Remove the appended ", " from the string.
+		invalidArgs.delete(invalidArgs.length() - 2, invalidArgs.length());
+		return new StyledText(Color.RED, String.format(ERROR, invalidArgs.toString()));
+	}
 
+	/**
+	 * Instantiates and runs a new {@link ConsoleRepl}.
+	 *
+	 * @param args
+	 *            The path to a language implementation location, using any filesystem supported by
+	 *            Apache VFS.
+	 * @throws MetaborgException
+	 *             When Spoofax initialization fails.
+	 */
+	public static void main(String[] args) throws MetaborgException {
+		System.setProperty("org.apache.commons.logging.Log",
+				"org.apache.commons.logging.impl.NoOpLog");
 
-    /**
-     * Instantiates and runs a new {@link ConsoleRepl}.
-     *
-     * @param args
-     *            The path to a language implementation location, using any filesystem supported by Apache VFS.
-     * @throws MetaborgException
-     *             When Spoofax initialization fails.
-     */
-    public static void main(String[] args) throws MetaborgException {
-        System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog");
+		try (final Spoofax spoofax = new Spoofax(new ConsoleReplModule())) {
+			final Injector injector = spoofax.injector;
+			final IDisplay display = injector.getInstance(IDisplay.class);
+			final ConsoleRepl repl = injector.getInstance(ConsoleRepl.class);
 
-        try(final Spoofax spoofax = new Spoofax(new ConsoleReplModule())) {
-            final Injector injector = spoofax.injector;
-            final IDisplay display = injector.getInstance(IDisplay.class);
-            final ConsoleRepl repl = injector.getInstance(ConsoleRepl.class);
+			if (args.length == 1) {
+				final String arg = args[0];
+				if (arg.equals("--exit")) {
+					return;
+				}
+				repl.runOnce(":load " + args[0]);
+			} else if (args.length > 1) {
+				display.displayStyledText(error(args));
+			}
 
-            if(args.length == 1) {
-                final String arg = args[0];
-                if(arg.equals("--exit")) {
-                    return;
-                }
-                repl.runOnce(":load " + args[0]);
-            } else if(args.length > 1) {
-                display.displayStyledText(error(args));
-            }
-
-            repl.run();
-        }
-    }
+			repl.run();
+		}
+	}
 }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/ClassPathInterpreterLoader.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/ClassPathInterpreterLoader.java
@@ -15,68 +15,74 @@ import org.metaborg.meta.lang.dynsem.interpreter.DynSemVM;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 
 /**
- * Loads an interpreter that is present in the class path. This {@link IInterpreterLoader} uses reflection to load the
- * generated {@link DynSemEntryPoint} subclass. It instantiates a {@link PolyglotEngine} and initializes the interpreter
- * by evaluating the DynSem specification term.
+ * Loads an interpreter that is present in the class path.
+ * This {@link IInterpreterLoader} uses reflection to load the generated {@link DynSemEntryPoint}
+ * subclass.
+ * It instantiates a {@link PolyglotEngine} and initializes the interpreter by evaluating the DynSem
+ * specification term.
  */
 public class ClassPathInterpreterLoader implements IInterpreterLoader {
 
-    @Override public DynSemVM createInterpreterForLanguage(ILanguageImpl langImpl) throws MetaborgException {
-        try {
-            Properties props = loadDynSemProperties(langImpl);
-            String className = targetPackage(props) + "." + langName(props) + "Main";
-            Class<?> mainClass = ClassUtils.getClass(className);
-            DynSemVM vm = (DynSemVM) MethodUtils.invokeStaticMethod(mainClass, "createVM");
-            return vm;
-        } catch(ReflectiveOperationException | ClassCastException e) {
-            throw new MetaborgException("Could not find the main class of the "
-                    + "interpreter.\nIs the generated interpreter on your classpath?");
-        }
-    }
+	@Override
+	public DynSemVM createInterpreterForLanguage(ILanguageImpl langImpl) throws MetaborgException {
+		try {
+			Properties props = loadDynSemProperties(langImpl);
+			String className = targetPackage(props) + "." + langName(props) + "Main";
+			Class<?> mainClass = ClassUtils.getClass(className);
+			DynSemVM vm = (DynSemVM) MethodUtils.invokeStaticMethod(mainClass, "createVM");
+			return vm;
+		} catch (ReflectiveOperationException | ClassCastException e) {
+			throw new MetaborgException("Could not find the main class of the "
+					+ "interpreter.\nIs the generated interpreter on your classpath?");
+		}
+	}
 
-    private static String langName(Properties props) {
-        return props.getProperty("source.langname");
-    }
+	private static String langName(Properties props) {
+		return props.getProperty("source.langname");
+	}
 
-    private static String targetPackage(Properties props) {
-        String groupId = props.getProperty("project.groupid");
-        String artifactId = props.getProperty("project.artifactid");
+	private static String targetPackage(Properties props) {
+		String groupId = props.getProperty("project.groupid");
+		String artifactId = props.getProperty("project.artifactid");
 
-        return props.getProperty("project.javapackage", groupId + '.' + artifactId + ".generated");
-    }
+		return props.getProperty("project.javapackage", groupId + '.' + artifactId + ".generated");
+	}
 
-    /*
-     * Loads the required configurations from the dynsem.properties file parsed as a Properties object.
-     */
-    private static Properties loadDynSemProperties(ILanguageImpl langImpl) throws MetaborgException {
-        FileObject dynSemPropertiesFile = findDynSemPropertiesFileForLanguage(langImpl);
-        Properties dynSemProperties = new Properties();
-        try(InputStream in = dynSemPropertiesFile.getContent().getInputStream()) {
-            dynSemProperties.load(in);
-        } catch(IOException e) {
-            throw new MetaborgException("Error when trying to load \"dynsem.properties\".");
-        }
+	/*
+	 * Loads the required configurations from the dynsem.properties file parsed as a Properties
+	 * object.
+	 */
+	private static Properties loadDynSemProperties(ILanguageImpl langImpl)
+			throws MetaborgException {
+		FileObject dynSemPropertiesFile = findDynSemPropertiesFileForLanguage(langImpl);
+		Properties dynSemProperties = new Properties();
+		try (InputStream in = dynSemPropertiesFile.getContent().getInputStream()) {
+			dynSemProperties.load(in);
+		} catch (IOException e) {
+			throw new MetaborgException("Error when trying to load \"dynsem.properties\".");
+		}
 
-        return dynSemProperties;
-    }
+		return dynSemProperties;
+	}
 
-    private static FileObject findDynSemPropertiesFileForLanguage(ILanguageImpl langImpl) throws MetaborgException {
-        FileObject dynSemPropertiesFile = null;
-        for(FileObject fo : langImpl.locations()) {
-            try {
-                dynSemPropertiesFile = fo.getChild("dynsem.properties");
-                if(dynSemPropertiesFile != null) {
-                    break;
-                }
-            } catch(FileSystemException e) {
-                continue;
-            }
-        }
+	private static FileObject findDynSemPropertiesFileForLanguage(ILanguageImpl langImpl)
+			throws MetaborgException {
+		FileObject dynSemPropertiesFile = null;
+		for (FileObject fo : langImpl.locations()) {
+			try {
+				dynSemPropertiesFile = fo.getChild("dynsem.properties");
+				if (dynSemPropertiesFile != null) {
+					break;
+				}
+			} catch (FileSystemException e) {
+				continue;
+			}
+		}
 
-        if(dynSemPropertiesFile == null) {
-            throw new MetaborgException("Missing \"dynsem.properties\" file");
-        }
-        return dynSemPropertiesFile;
-    }
+		if (dynSemPropertiesFile == null) {
+			throw new MetaborgException("Missing \"dynsem.properties\" file");
+		}
+		return dynSemPropertiesFile;
+	}
 
 }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/StrategoEvaluationStrategy.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/StrategoEvaluationStrategy.java
@@ -27,10 +27,10 @@ public class StrategoEvaluationStrategy implements IEvaluationStrategy {
 	private IStrategoTerm env;
 
 	@Inject
-	public StrategoEvaluationStrategy(IStrategoCommon strategoCommon, ITermFactoryService termFactoryService) {
+	public StrategoEvaluationStrategy(IStrategoCommon strategoCommon,
+			ITermFactoryService termFactoryService) {
 		this.strategoCommon = strategoCommon;
 		this.termFactory = termFactoryService.getGeneric();
-
 	}
 
 	@Override
@@ -45,7 +45,8 @@ public class StrategoEvaluationStrategy implements IEvaluationStrategy {
 			env = strategoCommon.invoke(context.language(), context, term, INIT_TERM);
 		}
 
-		IStrategoTerm result = strategoCommon.invoke(context.language(), context, termFactory.makeTuple(term, env), EVAL_TERM);
+		IStrategoTerm result = strategoCommon.invoke(context.language(), context,
+				termFactory.makeTuple(term, env), EVAL_TERM);
 
 		if (Tools.isTermTuple(result)) {
 			int subterms = result.getSubtermCount();
@@ -55,11 +56,14 @@ public class StrategoEvaluationStrategy implements IEvaluationStrategy {
 				env = newEnv;
 				return value;
 			} else {
-				throw new MetaborgException(String.format("Evaluation result expected: Tuple of 2. Found: Tuple of %d", subterms));
+				throw new MetaborgException(String.format(
+						"Evaluation result expected: Tuple of 2. Found: Tuple of %d", subterms));
 			}
 		} else {
 			// TODO give useful 'found' if possible
-			throw new MetaborgException(String.format("Evaluation result expected: Tuple. Found: %s", "<result.getTermType()=" + result.getTermType() + ">"));
+			throw new MetaborgException(
+					String.format("Evaluation result expected: Tuple. Found: %s",
+							"<result.getTermType()=" + result.getTermType() + ">"));
 		}
 
 	}

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/StrategoEvaluationStrategy.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/strategies/StrategoEvaluationStrategy.java
@@ -11,6 +11,10 @@ import org.spoofax.interpreter.terms.ITermFactory;
 
 import com.google.inject.Inject;
 
+
+/**
+ * An {@link IEvaluationStrategy} for Stratego-based languages.
+ */
 public class StrategoEvaluationStrategy implements IEvaluationStrategy {
 
 	// TODO: hardcoded init and eval terms
@@ -26,6 +30,17 @@ public class StrategoEvaluationStrategy implements IEvaluationStrategy {
 	 */
 	private IStrategoTerm env;
 
+	/**
+	 * Construct a new {@link StrategoEvaluationStrategy}.
+	 * On the first {@link #evaluate(IStrategoTerm, IContext) call an
+	 * environment is initialised and subsequent calls will use this
+	 * envirnonment.
+	 *
+	 * @param strategoCommon
+	 *            The interface for all Statego related functionality.
+	 * @param termFactoryService
+	 *            The {@link ITermFactoryService} for retrieving an {@link ITermFactory}.
+	 */
 	@Inject
 	public StrategoEvaluationStrategy(IStrategoCommon strategoCommon,
 			ITermFactoryService termFactoryService) {

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleReplTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleReplTest.java
@@ -28,7 +28,6 @@ import org.metaborg.spoofax.shell.client.console.commands.ExitCommand;
 import org.metaborg.spoofax.shell.invoker.CommandNotFoundException;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
@@ -37,139 +36,142 @@ import com.google.inject.util.Modules;
  * Tests {@link ConsoleRepl}.
  */
 public class ConsoleReplTest {
-    private Injector injector;
-    private ConsoleRepl repl;
-    private ByteArrayInputStream in;
-    private ByteArrayOutputStream out;
-    private TerminalUserInterface ifaceSpy;
-    private ICommandInvoker invokerMock;
+	private Injector injector;
+	private ConsoleRepl repl;
+	private ByteArrayInputStream in;
+	private ByteArrayOutputStream out;
+	private TerminalUserInterface ifaceSpy;
+	private ICommandInvoker invokerMock;
 
-    /**
-     * Create an {@link Injector} with {@link Module} {@code overrides}.
-     *
-     * @param overrides
-     *            The module overrides.
-     */
-    private void createInjector(Module... overrides) {
-        Module overridden = Modules.override(replModule()).with(overrides);
-        try {
-            Spoofax spoofax = new Spoofax(overridden);
-            injector = spoofax.injector;
-        } catch(MetaborgException e) {
-            throw new MetaborgRuntimeException(e);
-        }
-    }
+	/**
+	 * Create an {@link Injector} with {@link Module} {@code overrides}.
+	 *
+	 * @param overrides
+	 *            The module overrides.
+	 */
+	private void createInjector(Module... overrides) {
+		Module overridden = Modules.override(replModule()).with(overrides);
+		try {
+			Spoofax spoofax = new Spoofax(overridden);
+			injector = spoofax.injector;
+		} catch (MetaborgException e) {
+			throw new MetaborgRuntimeException(e);
+		}
+	}
 
-    private ReplModule replModule() {
-        return new ConsoleReplModule();
-    }
+	private ReplModule replModule() {
+		return new ConsoleReplModule();
+	}
 
-    /**
-     * Setup and inject the {@link InputStream}s and {@link OutputStream}s.
-     *
-     * @param overrides
-     *            Module overrides w.r.t. ReplModule.
-     */
-    private void createRepl(Module... overrides) {
-        createInjector(overrides);
-        repl = injector.getInstance(ConsoleRepl.class);
-    }
+	/**
+	 * Setup and inject the {@link InputStream}s and {@link OutputStream}s.
+	 *
+	 * @param overrides
+	 *            Module overrides w.r.t. ReplModule.
+	 */
+	private void createRepl(Module... overrides) {
+		createInjector(overrides);
+		repl = injector.getInstance(ConsoleRepl.class);
+	}
 
-    /**
-     * Setup the input streams.
-     *
-     * @param inputString
-     *            The user input that will be simulated.
-     * @throws UnsupportedEncodingException
-     *             When UTF-8 is not supported.
-     */
-    private void setUp(String inputString) throws UnsupportedEncodingException {
-        in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
-        out = new ByteArrayOutputStream();
+	/**
+	 * Setup the input streams.
+	 *
+	 * @param inputString
+	 *            The user input that will be simulated.
+	 * @throws UnsupportedEncodingException
+	 *             When UTF-8 is not supported.
+	 */
+	private void setUp(String inputString) throws UnsupportedEncodingException {
+		in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
+		out = new ByteArrayOutputStream();
 
-        createInjector(replModule());
-    }
+		createInjector(replModule());
+	}
 
-    private void setUpCtrlD() throws IOException {
-        setUp(String.valueOf(C_D));
-        invokerMock = mock(ICommandInvoker.class, RETURNS_MOCKS);
+	private void setUpCtrlD() throws IOException {
+		setUp(String.valueOf(C_D));
+		invokerMock = mock(ICommandInvoker.class, RETURNS_MOCKS);
 
-        // Create a user input simulated ConsoleRepl with the mock invoker.
-        createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock));
-    }
+		// Create a user input simulated ConsoleRepl with the mock invoker.
+		createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock));
+	}
 
-    /**
-     * Test {@link ConsoleRepl#runOnce(String)}.
-     *
-     * @throws IOException
-     *             Should not happen.
-     * @throws CommandNotFoundException
-     *             Should not happen.
-     */
-    @Test
-    public void testRunOnce() throws IOException, CommandNotFoundException {
-        String fake = ":fakecommand foo";
-        setUp(fake);
-        invokerMock = mock(ICommandInvoker.class, RETURNS_MOCKS);
+	/**
+	 * Test {@link ConsoleRepl#runOnce(String)}.
+	 *
+	 * @throws IOException
+	 *             Should not happen.
+	 * @throws CommandNotFoundException
+	 *             Should not happen.
+	 */
+	@Test
+	public void testRunOnce() throws IOException, CommandNotFoundException {
+		String fake = ":fakecommand foo";
+		setUp(fake);
+		invokerMock = mock(ICommandInvoker.class, RETURNS_MOCKS);
 
-        // Create a user input simulated ConsoleRepl with the mock invoker.
-        createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock));
+		// Create a user input simulated ConsoleRepl with the mock invoker.
+		createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock));
 
-        repl.runOnce(fake);
-        verify(invokerMock, times(1)).execute(fake);
-    }
+		repl.runOnce(fake);
+		verify(invokerMock, times(1)).execute(fake);
+	}
 
-    /**
-     * Test whether the REPl exits when Control-D is pressed.
-     *
-     * @throws IOException
-     *             Should not happen.
-     * @throws CommandNotFoundException
-     *             Should not happen.
-     */
-    @Test
-    public void testCtrlDDoesExit() throws CommandNotFoundException, IOException {
-        setUpCtrlD();
-        repl.run();
-        // Ensure that the command invoker is never called with any command.
-        verify(invokerMock, never()).execute(anyString());
-    }
+	/**
+	 * Test whether the REPl exits when Control-D is pressed.
+	 *
+	 * @throws IOException
+	 *             Should not happen.
+	 * @throws CommandNotFoundException
+	 *             Should not happen.
+	 */
+	@Test
+	public void testCtrlDDoesExit() throws CommandNotFoundException, IOException {
+		setUpCtrlD();
+		repl.run();
+		// Ensure that the command invoker is never called with any command.
+		verify(invokerMock, never()).execute(anyString());
+	}
 
-    private void setUpExit() throws IOException {
-        setUp(":exit" + ENTER + ENTER + ":exit" + ENTER + ENTER);
-        createInjector(new UserInputSimulationModule(in, out));
-        invokerMock = spy(injector.getInstance(ICommandInvoker.class));
-        ifaceSpy = spy(injector.getInstance(TerminalUserInterface.class));
+	private void setUpExit() throws IOException {
+		setUp(":exit" + ENTER + ENTER + ":exit" + ENTER + ENTER);
+		createInjector(new UserInputSimulationModule(in, out));
+		invokerMock = spy(injector.getInstance(ICommandInvoker.class));
+		ifaceSpy = spy(injector.getInstance(TerminalUserInterface.class));
 
-        // Create a user input simulated ConsoleRepl with the mock invoker and mock editor.
-        createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock, ifaceSpy));
-    }
+		// Create a user input simulated ConsoleRepl with the mock invoker and
+		// mock editor.
+		createRepl(new UserInputSimulationModule(in, out), new MockModule(invokerMock, ifaceSpy));
+	}
 
-    /**
-     * Tests the {@link ExitCommand}.
-     *
-     * @throws IOException
-     *             Should not happen.
-     * @throws CommandNotFoundException
-     *             Should not happen.
-     */
-    @Test
-    public void testExitCommand() throws IOException, CommandNotFoundException {
-        setUpExit();
+	/**
+	 * Tests the {@link ExitCommand}.
+	 *
+	 * @throws IOException
+	 *             Should not happen.
+	 * @throws CommandNotFoundException
+	 *             Should not happen.
+	 */
+	@Test
+	public void testExitCommand() throws IOException, CommandNotFoundException {
+		setUpExit();
 
-        // Stub the invoker so that it returns an exit command which we can spy on.
-        ExitCommand exitCommandMock = spy(new ExitCommand(() -> repl));
-        when(invokerMock.commandFromName("exit")).thenReturn(exitCommandMock);
+		// Stub the invoker so that it returns an exit command which we can spy
+		// on.
+		ExitCommand exitCommandMock = spy(new ExitCommand(() -> repl));
+		when(invokerMock.commandFromName("exit")).thenReturn(exitCommandMock);
 
-        repl.run();
+		repl.run();
 
-        // Ensure that the command was given to the invoker just once.
-        verify(invokerMock, times(1)).execute(":exit");
+		// Ensure that the command was given to the invoker just once.
+		verify(invokerMock, times(1)).execute(":exit");
 
-        // Ensure that exitCommand was executed once.
-        verify(exitCommandMock, times(1)).execute();
+		// Ensure that exitCommand was executed once.
+		verify(exitCommandMock, times(1)).execute();
 
-        // Verify that the Editor was not asked for input after the exit command was executed.
-        verify(ifaceSpy, times(1)).getInput();
-    }
+		// Verify that the Editor was not asked for input after the exit command
+		// was executed.
+		verify(ifaceSpy, times(1)).getInput();
+	}
 }

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/strategies/ClassPathInterpreterLoaderTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/strategies/ClassPathInterpreterLoaderTest.java
@@ -1,374 +1,397 @@
-//package org.metaborg.spoofax.shell.client.console.strategies;
+// package org.metaborg.spoofax.shell.client.console.strategies;
 //
-//import static org.junit.Assert.*;
+// import static org.junit.Assert.*;
 //
-//import java.io.ByteArrayInputStream;
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.io.PrintWriter;
-//import java.nio.charset.Charset;
-//import java.util.ArrayList;
-//import java.util.Arrays;
-//import java.util.Collection;
-//import java.util.List;
-//import java.util.function.Supplier;
+// import java.io.ByteArrayInputStream;
+// import java.io.IOException;
+// import java.io.InputStream;
+// import java.io.PrintWriter;
+// import java.nio.charset.Charset;
+// import java.util.ArrayList;
+// import java.util.Arrays;
+// import java.util.Collection;
+// import java.util.List;
+// import java.util.function.Supplier;
 //
-//import org.apache.commons.vfs2.FileObject;
-//import org.apache.commons.vfs2.FileSystemException;
-//import org.apache.commons.vfs2.FileSystemManager;
-//import org.apache.commons.vfs2.VFS;
-//import org.junit.After;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.junit.runners.Parameterized;
-//import org.junit.runners.Parameterized.Parameters;
-//import org.metaborg.core.language.ILanguageImpl;
-//import org.metaborg.meta.lang.dynsem.interpreter.DynSemEntryPoint;
-//import org.metaborg.meta.lang.dynsem.interpreter.DynSemLanguage;
-//import org.metaborg.meta.lang.dynsem.interpreter.DynSemRule;
-//import org.metaborg.meta.lang.dynsem.interpreter.IDynSemLanguageParser;
-//import org.metaborg.meta.lang.dynsem.interpreter.ITermRegistry;
-//import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.JointRuleRoot;
-//import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleRegistry;
-//import org.metaborg.meta.lang.dynsem.interpreter.terms.ITermTransformer;
-//import org.metaborg.spoofax.shell.client.console.strategies.IInterpreterLoader.InterpreterLoadException;
-//import org.metaborg.util.resource.FileSelectorUtils;
-//import org.mockito.Mockito;
+// import org.apache.commons.vfs2.FileObject;
+// import org.apache.commons.vfs2.FileSystemException;
+// import org.apache.commons.vfs2.FileSystemManager;
+// import org.apache.commons.vfs2.VFS;
+// import org.junit.After;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.junit.runner.RunWith;
+// import org.junit.runners.Parameterized;
+// import org.junit.runners.Parameterized.Parameters;
+// import org.metaborg.core.language.ILanguageImpl;
+// import org.metaborg.meta.lang.dynsem.interpreter.DynSemEntryPoint;
+// import org.metaborg.meta.lang.dynsem.interpreter.DynSemLanguage;
+// import org.metaborg.meta.lang.dynsem.interpreter.DynSemRule;
+// import org.metaborg.meta.lang.dynsem.interpreter.IDynSemLanguageParser;
+// import org.metaborg.meta.lang.dynsem.interpreter.ITermRegistry;
+// import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.JointRuleRoot;
+// import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleRegistry;
+// import org.metaborg.meta.lang.dynsem.interpreter.terms.ITermTransformer;
+// import
+// org.metaborg.spoofax.shell.client.console.strategies.IInterpreterLoader.InterpreterLoadException;
+// import org.metaborg.util.resource.FileSelectorUtils;
+// import org.mockito.Mockito;
 //
-//import com.oracle.truffle.api.CallTarget;
-//import com.oracle.truffle.api.Truffle;
-//import com.oracle.truffle.api.TruffleLanguage;
-//import com.oracle.truffle.api.frame.VirtualFrame;
-//import com.oracle.truffle.api.instrument.Visualizer;
-//import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
-//import com.oracle.truffle.api.nodes.Node;
-//import com.oracle.truffle.api.nodes.RootNode;
-//import com.oracle.truffle.api.source.Source;
-//import com.oracle.truffle.api.vm.PolyglotEngine;
-//import com.oracle.truffle.api.vm.PolyglotEngine.Value;
+// import com.oracle.truffle.api.CallTarget;
+// import com.oracle.truffle.api.Truffle;
+// import com.oracle.truffle.api.TruffleLanguage;
+// import com.oracle.truffle.api.frame.VirtualFrame;
+// import com.oracle.truffle.api.instrument.Visualizer;
+// import
+// com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+// import com.oracle.truffle.api.nodes.Node;
+// import com.oracle.truffle.api.nodes.RootNode;
+// import com.oracle.truffle.api.source.Source;
+// import com.oracle.truffle.api.vm.PolyglotEngine;
+// import com.oracle.truffle.api.vm.PolyglotEngine.Value;
 //
-///**
-// * Tests loading of a "generated" interpreter that is on the class path. The interpreter entry point
+/// **
+// * Tests loading of a "generated" interpreter that is on the class path. The
+// interpreter entry point
 // * is defined in this test class.
 // */
-//@RunWith(Parameterized.class)
-//public class ClassPathInterpreterLoaderTest {
-//    private static final String NO_EXCEPTION = "No exception should be thrown";
-//    protected static final String SPEC_TERM_CONSTANT = "specification term";
-//    protected final ClassPathInterpreterLoader cpInterpLoader = new ClassPathInterpreterLoader();
-//    protected static final JointRuleRoot MOCK_RULE_ROOT = Mockito.mock(JointRuleRoot.class);
-//    protected ILanguageImpl mockLangImpl;
-//    @SuppressWarnings("unused")
-//    private static final TestCPLoaderLanguage LANG = TestCPLoaderLanguage.INSTANCE;
+// @RunWith(Parameterized.class)
+// public class ClassPathInterpreterLoaderTest {
+// private static final String NO_EXCEPTION = "No exception should be thrown";
+// protected static final String SPEC_TERM_CONSTANT = "specification term";
+// protected final ClassPathInterpreterLoader cpInterpLoader = new
+// ClassPathInterpreterLoader();
+// protected static final JointRuleRoot MOCK_RULE_ROOT =
+// Mockito.mock(JointRuleRoot.class);
+// protected ILanguageImpl mockLangImpl;
+// @SuppressWarnings("unused")
+// private static final TestCPLoaderLanguage LANG =
+// TestCPLoaderLanguage.INSTANCE;
 //
-//    private static boolean reachedLanguageParse = false;
-//    private final Iterable<FileObject> langImplLocations;
-//    private final String expectedExceptionMessage;
-//    private final Class<?> expectedExceptionCauseClass;
+// private static boolean reachedLanguageParse = false;
+// private final Iterable<FileObject> langImplLocations;
+// private final String expectedExceptionMessage;
+// private final Class<?> expectedExceptionCauseClass;
 //
-//    /**
-//     * @param langImplLocations
-//     *            The locations to stub {@link ILanguageImpl#locations()} with.
-//     * @param expectedExceptionMessage
-//     *            The expected {@link InterpreterLoadException} message if one is to be thrown, or
-//     *            null if the exception has an expected cause instead.
-//     * @param expectedExceptionCauseClass
-//     *            The expected cause for the {@link InterpreterLoadException}, or null if not used.
-//     */
-//    public ClassPathInterpreterLoaderTest(Supplier<Iterable<FileObject>> langImplLocations,
-//                                          String expectedExceptionMessage,
-//                                          Class<?> expectedExceptionCauseClass) {
-//        this.langImplLocations = langImplLocations.get();
-//        this.expectedExceptionMessage = expectedExceptionMessage;
-//        this.expectedExceptionCauseClass = expectedExceptionCauseClass;
-//    }
+// /**
+// * @param langImplLocations
+// * The locations to stub {@link ILanguageImpl#locations()} with.
+// * @param expectedExceptionMessage
+// * The expected {@link InterpreterLoadException} message if one is to be
+// thrown, or
+// * null if the exception has an expected cause instead.
+// * @param expectedExceptionCauseClass
+// * The expected cause for the {@link InterpreterLoadException}, or null if not
+// used.
+// */
+// public ClassPathInterpreterLoaderTest(Supplier<Iterable<FileObject>>
+// langImplLocations,
+// String expectedExceptionMessage,
+// Class<?> expectedExceptionCauseClass) {
+// this.langImplLocations = langImplLocations.get();
+// this.expectedExceptionMessage = expectedExceptionMessage;
+// this.expectedExceptionCauseClass = expectedExceptionCauseClass;
+// }
 //
-//    /**
-//     * Set up mocks.
-//     */
-//    @Before
-//    public void setUp() {
-//        mockLangImpl = Mockito.mock(ILanguageImpl.class);
-//        Mockito.when(mockLangImpl.locations()).thenReturn(langImplLocations);
-//    }
+// /**
+// * Set up mocks.
+// */
+// @Before
+// public void setUp() {
+// mockLangImpl = Mockito.mock(ILanguageImpl.class);
+// Mockito.when(mockLangImpl.locations()).thenReturn(langImplLocations);
+// }
 //
-//    /**
-//     * Delete RAM file system cache.
-//     *
-//     * @throws FileSystemException
-//     *             When something goes wrong when deleting.
-//     */
-//    @After
-//    public void tearDown() throws FileSystemException {
-//        FileSystemManager manager = VFS.getManager();
-//        FileObject root = manager.resolveFile("ram:///");
-//        manager.getFilesCache().clear(root.getFileSystem());
-//        root.delete(FileSelectorUtils.all());
-//    }
+// /**
+// * Delete RAM file system cache.
+// *
+// * @throws FileSystemException
+// * When something goes wrong when deleting.
+// */
+// @After
+// public void tearDown() throws FileSystemException {
+// FileSystemManager manager = VFS.getManager();
+// FileObject root = manager.resolveFile("ram:///");
+// manager.getFilesCache().clear(root.getFileSystem());
+// root.delete(FileSelectorUtils.all());
+// }
 //
-//    /**
-//     * @return The language locations to test against, to cover all branches.
-//     * @throws FileSystemException
-//     *             When file creation goes wrong.
-//     */
-//    @Parameters
-//    public static Collection<Object[]> languageLocationsParameters() throws FileSystemException {
-//        // Let each dynsem.properties (or lack thereof) be in separate, isolated directories.
-//        return Arrays.asList(new Object[][] {
-//                                              { goodWeatherLocations(VFS.getManager()
-//                                                  .resolveFile("ram:///rootDirOne/")),
-//                                                NO_EXCEPTION,
-//                                                null },
-//                                              { missingDynSemProperties(VFS.getManager()
-//                                                  .resolveFile("ram:///rootDirTwo/")),
-//                                                "Missing \"dynsem.properties\" file",
-//                                                null },
-//                                              { multipleLocations(VFS.getManager()
-//                                                  .resolveFile("ram:///rootDirThree/")),
-//                                                NO_EXCEPTION,
-//                                                null },
-//                                              { badWeatherLocations(VFS.getManager()
-//                                                  .resolveFile("ram:///rootDirFour/")),
-//                                                "Could not find the entry point to the"
-//                                                + " interpreter.\nIs the generated"
-//                                                + " interpreter on your classpath?", null } });
+// /**
+// * @return The language locations to test against, to cover all branches.
+// * @throws FileSystemException
+// * When file creation goes wrong.
+// */
+// @Parameters
+// public static Collection<Object[]> languageLocationsParameters() throws
+// FileSystemException {
+// // Let each dynsem.properties (or lack thereof) be in separate, isolated
+// directories.
+// return Arrays.asList(new Object[][] {
+// { goodWeatherLocations(VFS.getManager()
+// .resolveFile("ram:///rootDirOne/")),
+// NO_EXCEPTION,
+// null },
+// { missingDynSemProperties(VFS.getManager()
+// .resolveFile("ram:///rootDirTwo/")),
+// "Missing \"dynsem.properties\" file",
+// null },
+// { multipleLocations(VFS.getManager()
+// .resolveFile("ram:///rootDirThree/")),
+// NO_EXCEPTION,
+// null },
+// { badWeatherLocations(VFS.getManager()
+// .resolveFile("ram:///rootDirFour/")),
+// "Could not find the entry point to the"
+// + " interpreter.\nIs the generated"
+// + " interpreter on your classpath?", null } });
 //
-//    }
+// }
 //
-//    private static Supplier<List<FileObject>> goodWeatherLocations(FileObject rootDir) {
-//        return () -> {
-//            try {
-//                rootDir.createFolder();
-//                FileObject dynSemProperties = rootDir.resolveFile("dynsem.properties");
-//                dynSemProperties.createFile();
-//                PrintWriter printWriter =
-//                    new PrintWriter(dynSemProperties.getContent().getOutputStream());
-//                printWriter.println("project.javapackage = org.metaborg.spoofax.shell.core");
-//                printWriter
-//                    .println("source.langname = ClassPathInterpreterLoaderTest$TestCPLoader");
-//                printWriter.flush();
-//                printWriter.close();
-//                dynSemProperties.close();
-//                List<FileObject> res = new ArrayList<>(1);
-//                res.add(rootDir);
-//                return res;
-//            } catch (FileSystemException e) {
-//                fail("Should not happen.");
-//            }
-//            return null;
-//        };
-//    }
+// private static Supplier<List<FileObject>> goodWeatherLocations(FileObject
+// rootDir) {
+// return () -> {
+// try {
+// rootDir.createFolder();
+// FileObject dynSemProperties = rootDir.resolveFile("dynsem.properties");
+// dynSemProperties.createFile();
+// PrintWriter printWriter =
+// new PrintWriter(dynSemProperties.getContent().getOutputStream());
+// printWriter.println("project.javapackage = org.metaborg.spoofax.shell.core");
+// printWriter
+// .println("source.langname = ClassPathInterpreterLoaderTest$TestCPLoader");
+// printWriter.flush();
+// printWriter.close();
+// dynSemProperties.close();
+// List<FileObject> res = new ArrayList<>(1);
+// res.add(rootDir);
+// return res;
+// } catch (FileSystemException e) {
+// fail("Should not happen.");
+// }
+// return null;
+// };
+// }
 //
-//    private static Supplier<List<FileObject>> missingDynSemProperties(FileObject rootDir) {
-//        return () -> {
-//            try {
-//                rootDir.createFolder();
-//                FileObject noDynSemProperties = rootDir.resolveFile("nodynsem.properties");
-//                noDynSemProperties.createFile();
-//                PrintWriter printWriter =
-//                    new PrintWriter(noDynSemProperties.getContent().getOutputStream());
-//                printWriter.println("blabla");
-//                printWriter.flush();
-//                printWriter.close();
-//                noDynSemProperties.close();
-//                List<FileObject> res = new ArrayList<>(1);
-//                res.add(rootDir);
-//                return res;
-//            } catch (FileSystemException e) {
-//                fail("Should not happen.");
-//            }
-//            return null;
-//        };
-//    }
+// private static Supplier<List<FileObject>> missingDynSemProperties(FileObject
+// rootDir) {
+// return () -> {
+// try {
+// rootDir.createFolder();
+// FileObject noDynSemProperties = rootDir.resolveFile("nodynsem.properties");
+// noDynSemProperties.createFile();
+// PrintWriter printWriter =
+// new PrintWriter(noDynSemProperties.getContent().getOutputStream());
+// printWriter.println("blabla");
+// printWriter.flush();
+// printWriter.close();
+// noDynSemProperties.close();
+// List<FileObject> res = new ArrayList<>(1);
+// res.add(rootDir);
+// return res;
+// } catch (FileSystemException e) {
+// fail("Should not happen.");
+// }
+// return null;
+// };
+// }
 //
-//    private static Supplier<Iterable<FileObject>> multipleLocations(FileObject rootDir) {
-//        return () -> {
-//            try {
-//                rootDir.createFolder();
-//                FileObject someRootDir = rootDir.resolveFile("someRootDir/");
-//                someRootDir.createFolder();
-//                FileObject anotherRootDir = rootDir.resolveFile("anotherRootDir/");
-//                anotherRootDir.createFolder();
-//                List<FileObject> missingDynSemProperties =
-//                    missingDynSemProperties(anotherRootDir).get();
-//                List<FileObject> goodWeatherLocations = goodWeatherLocations(someRootDir).get();
-//                missingDynSemProperties.addAll(goodWeatherLocations);
+// private static Supplier<Iterable<FileObject>> multipleLocations(FileObject
+// rootDir) {
+// return () -> {
+// try {
+// rootDir.createFolder();
+// FileObject someRootDir = rootDir.resolveFile("someRootDir/");
+// someRootDir.createFolder();
+// FileObject anotherRootDir = rootDir.resolveFile("anotherRootDir/");
+// anotherRootDir.createFolder();
+// List<FileObject> missingDynSemProperties =
+// missingDynSemProperties(anotherRootDir).get();
+// List<FileObject> goodWeatherLocations =
+// goodWeatherLocations(someRootDir).get();
+// missingDynSemProperties.addAll(goodWeatherLocations);
 //
-//                return missingDynSemProperties;
-//            } catch (FileSystemException e) {
-//                fail("Should not happen.");
-//            }
-//            return null;
-//        };
-//    }
+// return missingDynSemProperties;
+// } catch (FileSystemException e) {
+// fail("Should not happen.");
+// }
+// return null;
+// };
+// }
 //
-//    private static Supplier<List<FileObject>> badWeatherLocations(FileObject rootDir) {
-//        return () -> {
-//            try {
-//                rootDir.createFolder();
-//                FileObject dynSemProperties = rootDir.resolveFile("dynsem.properties");
-//                dynSemProperties.createFile();
-//                PrintWriter printWriter =
-//                    new PrintWriter(dynSemProperties.getContent().getOutputStream());
-//                printWriter.println("project.javapackage = non.existing.package");
-//                printWriter.println("source.langname = NonExistingLanguage");
-//                printWriter.flush();
-//                printWriter.close();
-//                dynSemProperties.close();
-//                List<FileObject> res = new ArrayList<>(1);
-//                res.add(rootDir);
-//                return res;
-//            } catch (FileSystemException e) {
-//                fail("Should not happen.");
-//            }
-//            return null;
-//        };
-//    }
+// private static Supplier<List<FileObject>> badWeatherLocations(FileObject
+// rootDir) {
+// return () -> {
+// try {
+// rootDir.createFolder();
+// FileObject dynSemProperties = rootDir.resolveFile("dynsem.properties");
+// dynSemProperties.createFile();
+// PrintWriter printWriter =
+// new PrintWriter(dynSemProperties.getContent().getOutputStream());
+// printWriter.println("project.javapackage = non.existing.package");
+// printWriter.println("source.langname = NonExistingLanguage");
+// printWriter.flush();
+// printWriter.close();
+// dynSemProperties.close();
+// List<FileObject> res = new ArrayList<>(1);
+// res.add(rootDir);
+// return res;
+// } catch (FileSystemException e) {
+// fail("Should not happen.");
+// }
+// return null;
+// };
+// }
 //
-//    /**
-//     * Tests loading the interpreter.
-//     *
-//     * @throws Exception
-//     *             when loading the interpreter throws one.
-//     */
-//    // Method length is ignored because this is just a test.
-//    // CHECKSTYLE.OFF: MethodLength
-//    @Test
-//    public void testLoadInterpreterForLanguage() throws Exception {
-//        try {
-//            // This should load the language, finding its canonical class name through the mocked
-//            // dynsem.properties initialized above.
-//            PolyglotEngine engine = cpInterpLoader.loadInterpreterForLanguage(mockLangImpl);
+// /**
+// * Tests loading the interpreter.
+// *
+// * @throws Exception
+// * when loading the interpreter throws one.
+// */
+// // Method length is ignored because this is just a test.
+// // CHECKSTYLE.OFF: MethodLength
+// @Test
+// public void testLoadInterpreterForLanguage() throws Exception {
+// try {
+// // This should load the language, finding its canonical class name through
+// the mocked
+// // dynsem.properties initialized above.
+// PolyglotEngine engine =
+// cpInterpLoader.loadInterpreterForLanguage(mockLangImpl);
 //
-//            // Test whether the test should not throw an exception, fail otherwise.
-//            assertEquals(expectedExceptionMessage, NO_EXCEPTION);
-//            assertNull(expectedExceptionCauseClass);
+// // Test whether the test should not throw an exception, fail otherwise.
+// assertEquals(expectedExceptionMessage, NO_EXCEPTION);
+// assertNull(expectedExceptionCauseClass);
 //
-//            // Test finding a rule.
-//            Value testRuleValue = engine.findGlobalSymbol("testrule/TestCtor/0");
-//            DynSemRule testRule = testRuleValue.as(DynSemRule.class);
+// // Test finding a rule.
+// Value testRuleValue = engine.findGlobalSymbol("testrule/TestCtor/0");
+// DynSemRule testRule = testRuleValue.as(DynSemRule.class);
 //
-//            assertEquals(testRule.getRuleTarget(), MOCK_RULE_ROOT);
+// assertEquals(testRule.getRuleTarget(), MOCK_RULE_ROOT);
 //
-//            // Assert that the parse method of the test language class was reached.
-//            assertTrue(reachedLanguageParse);
-//        } catch (IOException e) {
-//            throw new Exception(e);
-//        } catch (InterpreterLoadException e) {
-//            if (expectedExceptionMessage != null) {
-//                assertEquals(expectedExceptionMessage, e.getMessage());
-//            } else {
-//                assertNotNull(expectedExceptionCauseClass);
-//                assertEquals(expectedExceptionCauseClass, e.getCause().getClass());
-//            }
-//        }
-//    }
-//    // CHECKSTYLE.ON: MethodLength
+// // Assert that the parse method of the test language class was reached.
+// assertTrue(reachedLanguageParse);
+// } catch (IOException e) {
+// throw new Exception(e);
+// } catch (InterpreterLoadException e) {
+// if (expectedExceptionMessage != null) {
+// assertEquals(expectedExceptionMessage, e.getMessage());
+// } else {
+// assertNotNull(expectedExceptionCauseClass);
+// assertEquals(expectedExceptionCauseClass, e.getCause().getClass());
+// }
+// }
+// }
+// // CHECKSTYLE.ON: MethodLength
 //
-//    /**
-//     * Test {@link DynSemEntryPoint}.
-//     */
-//    public static final class TestCPLoaderEntryPoint extends DynSemEntryPoint {
+// /**
+// * Test {@link DynSemEntryPoint}.
+// */
+// public static final class TestCPLoaderEntryPoint extends DynSemEntryPoint {
 //
-//        /**
-//         * Inject mocked and stubbed dependencies.
-//         */
-//        public TestCPLoaderEntryPoint() {
-//            super(mockParser(), mockTransformer(), mockTermRegistry(), mockRuleRegistry());
-//        }
+// /**
+// * Inject mocked and stubbed dependencies.
+// */
+// public TestCPLoaderEntryPoint() {
+// super(mockParser(), mockTransformer(), mockTermRegistry(),
+// mockRuleRegistry());
+// }
 //
-//        private static IDynSemLanguageParser mockParser() {
-//            return null;
-//        }
+// private static IDynSemLanguageParser mockParser() {
+// return null;
+// }
 //
-//        private static ITermTransformer mockTransformer() {
-//            return null;
-//        }
+// private static ITermTransformer mockTransformer() {
+// return null;
+// }
 //
-//        @SuppressWarnings({ "rawtypes", "unchecked" })
-//        private static ITermRegistry mockTermRegistry() {
-//            ITermRegistry mock = Mockito.mock(ITermRegistry.class);
-//            return (ITermRegistry) Mockito.when(mock.getConstructorClass("TestCtor", 0))
-//                .thenReturn((Class) ClassPathInterpreterLoaderTest.class).getMock();
-//        }
+// @SuppressWarnings({ "rawtypes", "unchecked" })
+// private static ITermRegistry mockTermRegistry() {
+// ITermRegistry mock = Mockito.mock(ITermRegistry.class);
+// return (ITermRegistry) Mockito.when(mock.getConstructorClass("TestCtor", 0))
+// .thenReturn((Class) ClassPathInterpreterLoaderTest.class).getMock();
+// }
 //
-//        private static RuleRegistry mockRuleRegistry() {
-//            RuleRegistry mock = Mockito.mock(RuleRegistry.class);
-//            Mockito.when(mock.lookupRules("testrule", ClassPathInterpreterLoaderTest.class))
-//                .thenReturn(MOCK_RULE_ROOT);
-//            return mock;
-//        }
+// private static RuleRegistry mockRuleRegistry() {
+// RuleRegistry mock = Mockito.mock(RuleRegistry.class);
+// Mockito.when(mock.lookupRules("testrule",
+// ClassPathInterpreterLoaderTest.class))
+// .thenReturn(MOCK_RULE_ROOT);
+// return mock;
+// }
 //
-//        @Override
-//        public String getMimeType() {
-//            return "application/x-test-cp-loader-lang";
-//        }
+// @Override
+// public String getMimeType() {
+// return "application/x-test-cp-loader-lang";
+// }
 //
-//        @Override
-//        public InputStream getSpecificationTerm() {
-//            // Specification term is just a test string to assert equality.
-//            return new ByteArrayInputStream(SPEC_TERM_CONSTANT.getBytes(Charset.forName("UTF-8")));
-//        }
-//    }
+// @Override
+// public InputStream getSpecificationTerm() {
+// // Specification term is just a test string to assert equality.
+// return new
+// ByteArrayInputStream(SPEC_TERM_CONSTANT.getBytes(Charset.forName("UTF-8")));
+// }
+// }
 //
-//    /**
-//     * Test {@link TruffleLanguage}.
-//     */
-//    @TruffleLanguage.Registration(name = "TestDynSemLang", version = "0.1",
-//        mimeType = "application/x-test-cp-loader-lang")
-//    public static final class TestCPLoaderLanguage extends DynSemLanguage {
-//        public static final TestCPLoaderLanguage INSTANCE = new TestCPLoaderLanguage();
+// /**
+// * Test {@link TruffleLanguage}.
+// */
+// @TruffleLanguage.Registration(name = "TestDynSemLang", version = "0.1",
+// mimeType = "application/x-test-cp-loader-lang")
+// public static final class TestCPLoaderLanguage extends DynSemLanguage {
+// public static final TestCPLoaderLanguage INSTANCE = new
+// TestCPLoaderLanguage();
 //
-//        @Override
-//        protected CallTarget parse(Source code, Node context, String... argumentNames)
-//            throws IOException {
+// @Override
+// protected CallTarget parse(Source code, Node context, String...
+// argumentNames)
+// throws IOException {
 //
-//            // Test that the specification term is passed correctly.
-//            assertTrue(code.getCode().equals(SPEC_TERM_CONSTANT));
-//            // Set boolean flag so that it can be asserted that this method was reached.
-//            reachedLanguageParse = true;
+// // Test that the specification term is passed correctly.
+// assertTrue(code.getCode().equals(SPEC_TERM_CONSTANT));
+// // Set boolean flag so that it can be asserted that this method was reached.
+// reachedLanguageParse = true;
 //
-//            return Truffle.getRuntime()
-//                .createCallTarget(new RootNode(TestCPLoaderLanguage.class, null, null) {
-//                    @Override
-//                    public Object execute(VirtualFrame frame) {
-//                        return null;
-//                    }
-//                });
-//        }
+// return Truffle.getRuntime()
+// .createCallTarget(new RootNode(TestCPLoaderLanguage.class, null, null) {
+// @Override
+// public Object execute(VirtualFrame frame) {
+// return null;
+// }
+// });
+// }
 //
-//        @Override
-//        public boolean isSafeComponentsEnabled() {
-//            return false;
-//        }
+// @Override
+// public boolean isSafeComponentsEnabled() {
+// return false;
+// }
 //
-//        @Override
-//        public boolean isFullBacktrackingEnabled() {
-//            return false;
-//        }
+// @Override
+// public boolean isFullBacktrackingEnabled() {
+// return false;
+// }
 //
-//        @Override
-//        public boolean isTermCachingEnabled() {
-//            return false;
-//        }
+// @Override
+// public boolean isTermCachingEnabled() {
+// return false;
+// }
 //
-//        @Override
-//        public boolean isDEBUG() {
-//            // TODO: implement method; generated stub.
-//            return false;
-//        }
+// @Override
+// public boolean isDEBUG() {
+// // TODO: implement method; generated stub.
+// return false;
+// }
 //
-//        @Override
-//        protected Visualizer getVisualizer() {
-//            // TODO: implement method; generated stub.
-//            return null;
-//        }
+// @Override
+// protected Visualizer getVisualizer() {
+// // TODO: implement method; generated stub.
+// return null;
+// }
 //
-//        @Override
-//        protected WrapperNode createWrapperNode(Node node) {
-//            // TODO: implement method; generated stub.
-//            return null;
-//        }
-//    }
-//}
+// @Override
+// protected WrapperNode createWrapperNode(Node node) {
+// // TODO: implement method; generated stub.
+// return null;
+// }
+// }
+// }

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/strategies/DynSemEvaluationStrategyTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/strategies/DynSemEvaluationStrategyTest.java
@@ -1,193 +1,204 @@
-//package org.metaborg.spoofax.shell.client.console.strategies;
+// package org.metaborg.spoofax.shell.client.console.strategies;
 //
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertTrue;
-//import static org.junit.Assert.fail;
-//import static org.mockito.Matchers.any;
-//import static org.mockito.Matchers.anyMap;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.when;
+// import static org.junit.Assert.assertEquals;
+// import static org.junit.Assert.assertTrue;
+// import static org.junit.Assert.fail;
+// import static org.mockito.Matchers.any;
+// import static org.mockito.Matchers.anyMap;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.when;
 //
-//import java.io.IOException;
-//import java.util.Arrays;
-//import java.util.Collection;
-//import java.util.HashMap;
-//import java.util.Map;
+// import java.io.IOException;
+// import java.util.Arrays;
+// import java.util.Collection;
+// import java.util.HashMap;
+// import java.util.Map;
 //
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.junit.runners.Parameterized;
-//import org.junit.runners.Parameterized.Parameters;
-//import org.metaborg.core.MetaborgException;
-//import org.metaborg.core.context.IContext;
-//import org.metaborg.core.language.ILanguageImpl;
-//import org.metaborg.meta.lang.dynsem.interpreter.DynSemVM;
-//import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.ITermInstanceChecker;
-//import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleResult;
-//import org.metaborg.meta.lang.dynsem.interpreter.terms.ITerm;
-//import org.metaborg.meta.lang.dynsem.interpreter.terms.ITermTransformer;
-//import org.metaborg.spoofax.core.SpoofaxModule;
-//import org.metaborg.spoofax.core.terms.ITermFactoryService;
-//import org.mockito.Mockito;
-//import org.mockito.invocation.InvocationOnMock;
-//import org.mockito.stubbing.Answer;
-//import org.spoofax.interpreter.terms.IStrategoAppl;
-//import org.spoofax.interpreter.terms.IStrategoTerm;
-//import org.spoofax.interpreter.terms.ITermFactory;
+// import org.junit.Test;
+// import org.junit.runner.RunWith;
+// import org.junit.runners.Parameterized;
+// import org.junit.runners.Parameterized.Parameters;
+// import org.metaborg.core.MetaborgException;
+// import org.metaborg.core.context.IContext;
+// import org.metaborg.core.language.ILanguageImpl;
+// import org.metaborg.meta.lang.dynsem.interpreter.DynSemVM;
+// import
+// org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.ITermInstanceChecker;
+// import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleResult;
+// import org.metaborg.meta.lang.dynsem.interpreter.terms.ITerm;
+// import org.metaborg.meta.lang.dynsem.interpreter.terms.ITermTransformer;
+// import org.metaborg.spoofax.core.SpoofaxModule;
+// import org.metaborg.spoofax.core.terms.ITermFactoryService;
+// import org.mockito.Mockito;
+// import org.mockito.invocation.InvocationOnMock;
+// import org.mockito.stubbing.Answer;
+// import org.spoofax.interpreter.terms.IStrategoAppl;
+// import org.spoofax.interpreter.terms.IStrategoTerm;
+// import org.spoofax.interpreter.terms.ITermFactory;
 //
-//import com.google.inject.Guice;
-//import com.google.inject.Injector;
-//import com.oracle.truffle.api.vm.PolyglotEngine;
-//import com.oracle.truffle.api.vm.PolyglotEngine.Value;
+// import com.google.inject.Guice;
+// import com.google.inject.Injector;
+// import com.oracle.truffle.api.vm.PolyglotEngine;
+// import com.oracle.truffle.api.vm.PolyglotEngine.Value;
 //
-///**
+/// **
 // * Tests the {@link DynSemEvaluationStrategy}.
 // */
-//@RunWith(Parameterized.class)
-//public class DynSemEvaluationStrategyTest {
-//    private final DynSemEvaluationStrategy evalStrategy;
-//    private final IStrategoTerm input;
-//    private static final int DEFAULT_SHELL_RULE_ANSWER = 42;
-//    private static final String NO_EXCEPTION = "No exception should be thrown";
-//    private final String expectedExceptionMessage;
+// @RunWith(Parameterized.class)
+// public class DynSemEvaluationStrategyTest {
+// private final DynSemEvaluationStrategy evalStrategy;
+// private final IStrategoTerm input;
+// private static final int DEFAULT_SHELL_RULE_ANSWER = 42;
+// private static final String NO_EXCEPTION = "No exception should be thrown";
+// private final String expectedExceptionMessage;
 //
-//    private static final Injector INJECTOR = Guice.createInjector(new SpoofaxModule());
+// private static final Injector INJECTOR = Guice.createInjector(new
+// SpoofaxModule());
 //
-//    /**
-//     * Set up the evaluation strategy with the {@link MockInterpreterLoader}.
-//     *
-//     * @param ruleKey
-//     *            The key of the shell rule, to cover the branch in the private rule lookup method.
-//     * @param mockInitRule
-//     *            The rule for initializing the environment.
-//     * @param input
-//     *            The {@link IStrategoTerm} test input.
-//     * @param expectedExceptionMessage
-//     *            The exception message that is expected when an exception has been thrown.
-//     */
-//    public DynSemEvaluationStrategyTest(String ruleKey, Value mockInitRule,
-//                                        IStrategoTerm input, String expectedExceptionMessage) {
-//        this.input = input;
-//        this.expectedExceptionMessage = expectedExceptionMessage;
-//        ITermFactoryService termFactService = INJECTOR.getInstance(ITermFactoryService.class);
-//        evalStrategy =
-//            new DynSemEvaluationStrategy(new MockInterpreterLoader(ruleKey, mockInitRule),
-//                                         termFactService);
-//    }
+// /**
+// * Set up the evaluation strategy with the {@link MockInterpreterLoader}.
+// *
+// * @param ruleKey
+// * The key of the shell rule, to cover the branch in the private rule lookup
+// method.
+// * @param mockInitRule
+// * The rule for initializing the environment.
+// * @param input
+// * The {@link IStrategoTerm} test input.
+// * @param expectedExceptionMessage
+// * The exception message that is expected when an exception has been thrown.
+// */
+// public DynSemEvaluationStrategyTest(String ruleKey, Value mockInitRule,
+// IStrategoTerm input, String expectedExceptionMessage) {
+// this.input = input;
+// this.expectedExceptionMessage = expectedExceptionMessage;
+// ITermFactoryService termFactService =
+// INJECTOR.getInstance(ITermFactoryService.class);
+// evalStrategy =
+// new DynSemEvaluationStrategy(new MockInterpreterLoader(ruleKey,
+// mockInitRule),
+// termFactService);
+// }
 //
-//    /**
-//     * @return Parameters for the tests.
-//     * @throws IOException
-//     *             Should not happen.
-//     */
-//    // CHECKSTYLE.OFF: MethodLength
-//    @Parameters(name = "{index}: {0}")
-//    public static Collection<Object[]> inputAndRuleParameters() throws IOException {
-//        ITermFactory termFact = INJECTOR.getInstance(ITermFactoryService.class).getGeneric();
-//        IStrategoAppl existingTerm =
-//            termFact.makeAppl(termFact.makeConstructor("Add", 2),
-//                              termFact.makeInt(0), termFact.makeInt(0));
+// /**
+// * @return Parameters for the tests.
+// * @throws IOException
+// * Should not happen.
+// */
+// // CHECKSTYLE.OFF: MethodLength
+// @Parameters(name = "{index}: {0}")
+// public static Collection<Object[]> inputAndRuleParameters() throws
+// IOException {
+// ITermFactory termFact =
+// INJECTOR.getInstance(ITermFactoryService.class).getGeneric();
+// IStrategoAppl existingTerm =
+// termFact.makeAppl(termFact.makeConstructor("Add", 2),
+// termFact.makeInt(0), termFact.makeInt(0));
 //
-//        IStrategoAppl nonExistingRuleForTerm =
-//            termFact.makeAppl(termFact.makeConstructor("nonExistingRuleForTerm", 2),
-//                              termFact.makeInt(0), termFact.makeInt(0));
+// IStrategoAppl nonExistingRuleForTerm =
+// termFact.makeAppl(termFact.makeConstructor("nonExistingRuleForTerm", 2),
+// termFact.makeInt(0), termFact.makeInt(0));
 //
-//        IStrategoTerm wrongTypeTerm = termFact.makeList();
-//        IStrategoTerm noSortTerm = termFact.makeAppl(termFact.makeConstructor("Thing", 0));
+// IStrategoTerm wrongTypeTerm = termFact.makeList();
+// IStrategoTerm noSortTerm =
+// termFact.makeAppl(termFact.makeConstructor("Thing", 0));
 //
-//        return Arrays
-//            .asList(new Object[][] { { "shell/Add/2", mockInitRule(), existingTerm, NO_EXCEPTION },
-//                                     { "shell/noSuchRule/2", mockInitRule(), nonExistingRuleForTerm,
-//                                       "No shell rule found to be applied "
-//                                       + "to term \"nonExistingRuleForTerm(0,0)\"." },
-//                                     { "shell/wrongArgumentType/0", mockInitRule(), wrongTypeTerm,
-//                                       "Expected a StrategoAppl, but a "
-//                                       + "StrategoList was found: \"[]\"." },
-//                                     { "shell/_Expr/1", mockInitRule(), noSortTerm,
-//                                       "No shell rule found to be applied "
-//                                       + "to term \"Thing\"." },
-//                                     { "shell/Thing/0", mockInitRule(), noSortTerm, NO_EXCEPTION },
-//                                     { "Non-existing init rule", null,
-//                                       noSortTerm, "No shell initialization rule found.\n"
-//                                               + "Initialize the semantic components for the"
-//                                               + " \"shell\" rules with a rule of the form "
-//                                               + "\"ShellInit() -init-> ShellInit() :: "
-//                                               + "<RW>*\"." } });
-//    }
-//    // CHECKSTYLE.ON: MethodLength
+// return Arrays
+// .asList(new Object[][] { { "shell/Add/2", mockInitRule(), existingTerm,
+// NO_EXCEPTION },
+// { "shell/noSuchRule/2", mockInitRule(), nonExistingRuleForTerm,
+// "No shell rule found to be applied "
+// + "to term \"nonExistingRuleForTerm(0,0)\"." },
+// { "shell/wrongArgumentType/0", mockInitRule(), wrongTypeTerm,
+// "Expected a StrategoAppl, but a "
+// + "StrategoList was found: \"[]\"." },
+// { "shell/_Expr/1", mockInitRule(), noSortTerm,
+// "No shell rule found to be applied "
+// + "to term \"Thing\"." },
+// { "shell/Thing/0", mockInitRule(), noSortTerm, NO_EXCEPTION },
+// { "Non-existing init rule", null,
+// noSortTerm, "No shell initialization rule found.\n"
+// + "Initialize the semantic components for the"
+// + " \"shell\" rules with a rule of the form "
+// + "\"ShellInit() -init-> ShellInit() :: "
+// + "<RW>*\"." } });
+// }
+// // CHECKSTYLE.ON: MethodLength
 //
-//    private static Value mockInitRule() throws IOException {
-//        // Mock the init rule.
-//        Value mockInitRuleResult = when(mock(Value.class).as(RuleResult.class))
-//            .thenReturn(new RuleResult(null, new Object[] { new HashMap<String, Integer>() }))
-//            .getMock();
-//        Value mockInitRule =
-//            when(mock(Value.class).execute(any())).thenReturn(mockInitRuleResult).getMock();
-//        return mockInitRule;
-//    }
+// private static Value mockInitRule() throws IOException {
+// // Mock the init rule.
+// Value mockInitRuleResult = when(mock(Value.class).as(RuleResult.class))
+// .thenReturn(new RuleResult(null, new Object[] { new HashMap<String,
+// Integer>() }))
+// .getMock();
+// Value mockInitRule =
+// when(mock(Value.class).execute(any())).thenReturn(mockInitRuleResult).getMock();
+// return mockInitRule;
+// }
 //
-//    /**
-//     * Tests the propagation of the execution environment (the semantic components).
-//     */
-//    @Test
-//    public void testEnvironmentPropagation() {
-//        try {
-//            // First invocation causes an update in the environment.
-//            IStrategoTerm firstResult =
-//                evalStrategy.evaluate(input, mock(IContext.class, Mockito.RETURNS_MOCKS));
-//            assertEquals("\"0\"", firstResult.toString());
+// /**
+// * Tests the propagation of the execution environment (the semantic
+// components).
+// */
+// @Test
+// public void testEnvironmentPropagation() {
+// try {
+// // First invocation causes an update in the environment.
+// IStrategoTerm firstResult =
+// evalStrategy.evaluate(input, mock(IContext.class, Mockito.RETURNS_MOCKS));
+// assertEquals("\"0\"", firstResult.toString());
 //
-//            // Second invocation has a different result due to a different environment.
-//            IStrategoTerm secondResult =
-//                evalStrategy.evaluate(input, mock(IContext.class, Mockito.RETURNS_MOCKS));
-//            assertTrue(secondResult.toString().contains(String.valueOf(DEFAULT_SHELL_RULE_ANSWER)));
-//            if (expectedExceptionMessage != NO_EXCEPTION) {
-//                fail("Exception was expected, but not thrown.");
-//            }
-//        } catch (MetaborgException e) {
-//            assertEquals(expectedExceptionMessage, e.getMessage());
-//        }
-//    }
+// // Second invocation has a different result due to a different environment.
+// IStrategoTerm secondResult =
+// evalStrategy.evaluate(input, mock(IContext.class, Mockito.RETURNS_MOCKS));
+// assertTrue(secondResult.toString().contains(String.valueOf(DEFAULT_SHELL_RULE_ANSWER)));
+// if (expectedExceptionMessage != NO_EXCEPTION) {
+// fail("Exception was expected, but not thrown.");
+// }
+// } catch (MetaborgException e) {
+// assertEquals(expectedExceptionMessage, e.getMessage());
+// }
+// }
 //
-//    /**
-//     * An {@link IInterpreterLoader} that returns a mock interpreter.
-//     */
-//    static final class MockInterpreterLoader implements IInterpreterLoader {
-//        private final String ruleKey;
-//        private final Value mockInitRule;
+// /**
+// * An {@link IInterpreterLoader} that returns a mock interpreter.
+// */
+// static final class MockInterpreterLoader implements IInterpreterLoader {
+// private final String ruleKey;
+// private final Value mockInitRule;
 //
-//        private MockInterpreterLoader(String ruleKey, Value mockInitRule) {
-//            this.ruleKey = ruleKey;
-//            this.mockInitRule = mockInitRule;
-//        }
+// private MockInterpreterLoader(String ruleKey, Value mockInitRule) {
+// this.ruleKey = ruleKey;
+// this.mockInitRule = mockInitRule;
+// }
 //
-//        // Method length is ignored because this is just a test.
-//        // CHECKSTYLE.OFF: MethodLength
-//        @Override
-//        public DynSemVM createInterpreterForLanguage(ILanguageImpl langImpl)
-//            throws MetaborgException {
-//            DynSemVM mockInterpreter = mock(DynSemVM.class);
+// // Method length is ignored because this is just a test.
+// // CHECKSTYLE.OFF: MethodLength
+// @Override
+// public DynSemVM createInterpreterForLanguage(ILanguageImpl langImpl)
+// throws MetaborgException {
+// DynSemVM mockInterpreter = mock(DynSemVM.class);
 //
-//            when(mockInterpreter.findGlobalSymbol("init/ShellInit/0")).thenReturn(mockInitRule);
+// when(mockInterpreter.findGlobalSymbol("init/ShellInit/0")).thenReturn(mockInitRule);
 //
-//            // Mock the shell rule. It extends the environment.
-//            Value mockRule = when(mock(Value.class).execute(any(), anyMap()))
-//                .thenAnswer(new Answer<Value>() {
-//                    @SuppressWarnings("unchecked")
-//                    @Override
-//                    public Value answer(InvocationOnMock invocation) throws Throwable {
-//                        Map<String, Integer> map = invocation.getArgument(1);
-//                        int result = map.getOrDefault("foo", 0);
-//                        map.put("foo", DEFAULT_SHELL_RULE_ANSWER);
-//                        return when(mock(Value.class).as(RuleResult.class))
-//                            .thenReturn(new RuleResult(result, new Object[] { map })).getMock();
-//                    }
-//                }).getMock();
-//            when(mockInterpreter.findGlobalSymbol(ruleKey)).thenReturn(mockRule);
+// // Mock the shell rule. It extends the environment.
+// Value mockRule = when(mock(Value.class).execute(any(), anyMap()))
+// .thenAnswer(new Answer<Value>() {
+// @SuppressWarnings("unchecked")
+// @Override
+// public Value answer(InvocationOnMock invocation) throws Throwable {
+// Map<String, Integer> map = invocation.getArgument(1);
+// int result = map.getOrDefault("foo", 0);
+// map.put("foo", DEFAULT_SHELL_RULE_ANSWER);
+// return when(mock(Value.class).as(RuleResult.class))
+// .thenReturn(new RuleResult(result, new Object[] { map })).getMock();
+// }
+// }).getMock();
+// when(mockInterpreter.findGlobalSymbol(ruleKey)).thenReturn(mockRule);
 //
-//            return mockInterpreter;
-//        }
-//        // CHECKSTYLE.ON: MethodLength
+// return mockInterpreter;
+// }
+// // CHECKSTYLE.ON: MethodLength
 //
-//    }
-//}
+// }
+// }

--- a/org.metaborg.spoofax.shell.core/pom.xml
+++ b/org.metaborg.spoofax.shell.core/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.metaborg.spoofax.shell.core</artifactId>
 
@@ -85,4 +82,171 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- Compile Java 8 sources. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgument>-proc:none</compilerArgument>
+        </configuration>
+      </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <dependencies>
+          <!-- Update Checkstyle to version 6.18 at runtime -->
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.18</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <violationSeverity>warning</violationSeverity>
+          <consoleOutput>false</consoleOutput>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>verify-style</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <!-- Using the latest version here breaks the reporting. -->
+        <!-- dependencies> <dependency> <groupId>net.sourceforge.pmd</groupId> <artifactId>pmd-java</artifactId> 
+          <version>5.4.0</version> </dependency> </dependencies -->
+        <configuration>
+          <verbose>true</verbose>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pmd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>cpd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
+          <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>findbugs-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+      </plugin>
+      <!-- JavaDoc -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+      </plugin>
+      <!-- JXR, (optional) dependency of both PMD and Checkstyle in order to xref sources. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <skipEmptyReport>false</skipEmptyReport>
+        </configuration>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <organization>
+    <name>Delft University of Technology</name>
+    <url>http://www.ewi.tudelft.nl/en</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <name>Justin van der Krieken</name>
+      <email>justin@vdkrieken.com</email>
+      <url>https://github.com/justinvdk</url>
+    </developer>
+    <developer>
+      <name>Wouter Smit</name>
+      <email>pathemeous@gmail.com</email>
+      <url>https://github.com/Pathemeous</url>
+    </developer>
+  </developers>
 </project>

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
@@ -43,85 +43,96 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 
 /**
- * This class binds the core classes. It is intended to be subclassed by client implementations. These subclasses should
- * bind their implementations of {@link IRepl} and either {@link IResultVisitor} or {@link IDisplay} (which is also an
- * {@link IResultVisitor}).
+ * This class binds the core classes.
+ * It is intended to be subclassed by client implementations.
+ * These subclasses should bind their implementations of {@link IRepl} and either
+ * {@link IResultVisitor} or {@link IDisplay}
+ * (which is also an {@link IResultVisitor}).
  */
 public abstract class ReplModule extends AbstractModule {
-    @Override protected void configure() {
-        MapBinder<String, IReplCommand> commandBinder =
-            MapBinder.newMapBinder(binder(), String.class, IReplCommand.class);
-        MapBinder<String, IEvaluationStrategy> evalStrategyBinder =
-            MapBinder.newMapBinder(binder(), String.class, IEvaluationStrategy.class);
-        bindCommands(commandBinder);
-        bindEvalStrategies(evalStrategyBinder);
-        bindFactories();
-    }
+	@Override
+	protected void configure() {
+		MapBinder<String, IReplCommand> commandBinder = MapBinder.newMapBinder(binder(),
+				String.class, IReplCommand.class);
+		MapBinder<String, IEvaluationStrategy> evalStrategyBinder = MapBinder.newMapBinder(binder(),
+				String.class, IEvaluationStrategy.class);
+		bindCommands(commandBinder);
+		bindEvalStrategies(evalStrategyBinder);
+		bindFactories();
+	}
 
+	/**
+	 * Binds the default commands.
+	 *
+	 * @param commandBinder
+	 *            The {@link MapBinder} for binding the commands to their names.
+	 */
+	protected void bindCommands(MapBinder<String, IReplCommand> commandBinder) {
+		commandBinder.addBinding("help").to(HelpCommand.class);
+		commandBinder.addBinding("load").to(LanguageCommand.class);
+		bind(IReplCommand.class).annotatedWith(Names.named("default_command"))
+				.to(DefaultCommand.class);
+		bind(ICommandInvoker.class).to(SpoofaxCommandInvoker.class);
+	}
 
-    /**
-     * Binds the default commands.
-     *
-     * @param commandBinder
-     *            The {@link MapBinder} for binding the commands to their names.
-     */
-    protected void bindCommands(MapBinder<String, IReplCommand> commandBinder) {
-        commandBinder.addBinding("help").to(HelpCommand.class);
-        commandBinder.addBinding("load").to(LanguageCommand.class);
-        bind(IReplCommand.class).annotatedWith(Names.named("default_command")).to(DefaultCommand.class);
-        bind(ICommandInvoker.class).to(SpoofaxCommandInvoker.class);
-    }
+	/**
+	 * Binds the evaluation strategies.
+	 *
+	 * @param evalStrategyBinder
+	 *            The {@link MapBinder} for binding the strategies to their names.
+	 */
+	protected void bindEvalStrategies(MapBinder<String, IEvaluationStrategy> evalStrategyBinder) {
+	}
 
-    /**
-     * Binds the evaluation strategies.
-     *
-     * @param evalStrategyBinder
-     *            The {@link MapBinder} for binding the strategies to their names.
-     */
-    protected void bindEvalStrategies(MapBinder<String, IEvaluationStrategy> evalStrategyBinder) {
-    }
+	/**
+	 * Binds implementations for the {@link IResultFactory} and the {@link IFunctionFactory}.
+	 */
+	protected void bindFactories() {
+		install(new FactoryModuleBuilder()
+				.implement(TransformResult.class, Names.named("parsed"),
+						TransformResult.Parsed.class)
+				.implement(TransformResult.class, Names.named("analyzed"),
+						TransformResult.Analyzed.class)
+				.build(IResultFactory.class));
 
-    /**
-     * Binds implementations for the {@link IResultFactory} and the {@link IFunctionFactory}.
-     */
-    protected void bindFactories() {
-        install(new FactoryModuleBuilder()
-            .implement(TransformResult.class, Names.named("parsed"), TransformResult.Parsed.class)
-            .implement(TransformResult.class, Names.named("analyzed"), TransformResult.Analyzed.class)
-            .build(IResultFactory.class));
+		// CHECKSTYLE.OFF: LineLength - Installs are rather long.
+		install(new FactoryModuleBuilder()
+				.implement(new TypeLiteral<FailableFunction<String, InputResult, IResult>>() {
+				}, Names.named("Source"), InputFunction.class)
+				.implement(new TypeLiteral<FailableFunction<String, InputResult, IResult>>() {
+				}, Names.named("Open"), OpenInputFunction.class)
+				.implement(new TypeLiteral<FailableFunction<InputResult, ParseResult, IResult>>() {
+				}, ParseFunction.class).implement(
+						new TypeLiteral<FailableFunction<ParseResult, AnalyzeResult, IResult>>() {
+						}, AnalyzeFunction.class)
+				.implement(
+						new TypeLiteral<FailableFunction<ParseResult, TransformResult, IResult>>() {
+						}, PTransformFunction.class)
+				.implement(
+						new TypeLiteral<FailableFunction<AnalyzeResult, TransformResult, IResult>>() {
+						}, ATransformFunction.class)
+				.implement(
+						new TypeLiteral<FailableFunction<ISpoofaxTermResult<?>, EvaluateResult, IResult>>() {
+						}, EvaluateFunction.class)
+				.build(IFunctionFactory.class));
+		// CHECKSTYLE.ON: LineLength
+	}
 
-        install(new FactoryModuleBuilder()
-            .implement(new TypeLiteral<FailableFunction<String, InputResult, IResult>>() {}, Names.named("Source"),
-                InputFunction.class)
-            .implement(new TypeLiteral<FailableFunction<String, InputResult, IResult>>() {}, Names.named("Open"),
-                OpenInputFunction.class)
-            .implement(new TypeLiteral<FailableFunction<InputResult, ParseResult, IResult>>() {}, ParseFunction.class)
-            .implement(new TypeLiteral<FailableFunction<ParseResult, AnalyzeResult, IResult>>() {},
-                AnalyzeFunction.class)
-            .implement(new TypeLiteral<FailableFunction<ParseResult, TransformResult, IResult>>() {},
-                PTransformFunction.class)
-            .implement(new TypeLiteral<FailableFunction<AnalyzeResult, TransformResult, IResult>>() {},
-                ATransformFunction.class)
-            .implement(new TypeLiteral<FailableFunction<ISpoofaxTermResult<?>, EvaluateResult, IResult>>() {},
-                EvaluateFunction.class)
-            .build(IFunctionFactory.class));
-    }
-
-
-    /**
-     * FIXME: hardcoded project returned here.
-     *
-     * @param resourceService
-     *            the Spoofax {@link ResourceService}
-     * @param projectService
-     *            the Spoofax {@link ISimpleProjectService}
-     * @return an {@link IProject}
-     * @throws MetaborgException
-     *             when creating a project failed
-     */
-    @Provides protected IProject project(IResourceService resourceService, ISimpleProjectService projectService)
-        throws MetaborgException {
-        FileObject resolve = resourceService.resolve(Files.createTempDir());
-        return projectService.create(resolve);
-    }
+	/**
+	 * FIXME: hardcoded project returned here.
+	 *
+	 * @param resourceService
+	 *            the Spoofax {@link ResourceService}
+	 * @param projectService
+	 *            the Spoofax {@link ISimpleProjectService}
+	 * @return an {@link IProject}
+	 * @throws MetaborgException
+	 *             when creating a project failed
+	 */
+	@Provides
+	protected IProject project(IResourceService resourceService,
+			ISimpleProjectService projectService) throws MetaborgException {
+		FileObject resolve = resourceService.resolve(Files.createTempDir());
+		return projectService.create(resolve);
+	}
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
@@ -8,15 +8,11 @@ import org.metaborg.core.MetaborgException;
 import org.metaborg.core.MetaborgRuntimeException;
 import org.metaborg.core.action.ITransformAction;
 import org.metaborg.core.analysis.AnalyzerFacet;
-import org.metaborg.core.language.ILanguageComponent;
-import org.metaborg.core.language.ILanguageDiscoveryRequest;
 import org.metaborg.core.language.ILanguageDiscoveryService;
 import org.metaborg.core.language.ILanguageImpl;
-import org.metaborg.core.language.LanguageUtils;
 import org.metaborg.core.menu.IMenuService;
 import org.metaborg.core.project.IProject;
 import org.metaborg.core.resource.IResourceService;
-import org.metaborg.spoofax.core.language.ComponentFactoryRequest;
 import org.metaborg.spoofax.shell.functions.IFunctionFactory;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.ExceptionResult;
@@ -30,127 +26,128 @@ import com.google.inject.Inject;
  * Represents a command that loads a Spoofax language.
  */
 public class LanguageCommand implements IReplCommand {
-    private static final String[] ARCHIVES = { "zip", "jar", "tar", "tgz", "tbz2", };
-    private final ILanguageDiscoveryService langDiscoveryService;
-    private final IResourceService resourceService;
-    private final IMenuService menuService;
-    private final ICommandInvoker invoker;
-    private final IProject project;
-    private final IFunctionFactory factory;
 
-    /**
-     * Instantiate a {@link LanguageCommand}. Loads all commands applicable to a lanugage.
-     *
-     * @param langDiscoveryService
-     *            the {@link ILanguageDiscoveryService}
-     * @param resourceService
-     *            the {@link IResourceService}
-     * @param invoker
-     *            the {@link ICommandInvoker}
-     * @param factory
-     *            the {@link IFunctionFactory}
-     * @param menuService
-     *            the {@link IMenuService}
-     * @param project
-     *            the associated {@link IProject}
-     */
-    @Inject
-    public LanguageCommand(ILanguageDiscoveryService langDiscoveryService,
-                           IResourceService resourceService, IMenuService menuService,
-                           ICommandInvoker invoker, IFunctionFactory factory,
-                           IProject project) { // FIXME: don't use the hardcoded @Provides
-        this.langDiscoveryService = langDiscoveryService;
-        this.resourceService = resourceService;
-        this.menuService = menuService;
-        this.invoker = invoker;
-        this.factory = factory;
-        this.project = project;
-    }
+	private static final String[] ARCHIVES = { "zip", "jar", "tar", "tgz", "tbz2", };
+	private final ILanguageDiscoveryService langDiscoveryService;
+	private final IResourceService resourceService;
+	private final IMenuService menuService;
+	private final ICommandInvoker invoker;
+	private final IProject project;
+	private final IFunctionFactory factory;
 
-    @Override
-    public String description() {
-        return "Load a language from a path.";
-    }
+	/**
+	 * Instantiate a {@link LanguageCommand}. Loads all commands applicable to a language.
+	 *
+	 * @param langDiscoveryService
+	 *            the {@link ILanguageDiscoveryService}
+	 * @param resourceService
+	 *            the {@link IResourceService}
+	 * @param invoker
+	 *            the {@link ICommandInvoker}
+	 * @param factory
+	 *            the {@link IFunctionFactory}
+	 * @param menuService
+	 *            the {@link IMenuService}
+	 * @param project
+	 *            the associated {@link IProject}
+	 */
+	@Inject
+	public LanguageCommand(ILanguageDiscoveryService langDiscoveryService,
+			IResourceService resourceService, IMenuService menuService, ICommandInvoker invoker,
+			IFunctionFactory factory, IProject project) {
+		// FIXME: don't use the hardcoded @Provides
+		this.langDiscoveryService = langDiscoveryService;
+		this.resourceService = resourceService;
+		this.menuService = menuService;
+		this.invoker = invoker;
+		this.factory = factory;
+		this.project = project;
+	}
 
-    /**
-     * Load a {@link ILanguageImpl} from a {@link FileObject}.
-     *
-     * @param langloc
-     *            the {@link FileObject} containing the {@link ILanguageImpl}
-     * @return the {@link ILanguageImpl}
-     * @throws MetaborgException
-     *             when loading fails
-     */
-    public ILanguageImpl load(FileObject langloc) throws MetaborgException {
-        Set<ILanguageImpl> langs = langDiscoveryService.scanLanguagesInDirectory(langloc);
-        
-        if (langs == null || langs.isEmpty()) {
-            throw new MetaborgException("Cannot find a language implementation");
-        }
+	@Override
+	public String description() {
+		return "Load a language from a path.";
+	}
 
-        if (langs.size() > 1) {
-            throw new MetaborgException("Multiple language implementations found. Please provide an unambiguous path.");
-        }
+	/**
+	 * Load a {@link ILanguageImpl} from a {@link FileObject}.
+	 *
+	 * @param langloc
+	 *            the {@link FileObject} containing the {@link ILanguageImpl}
+	 * @return the {@link ILanguageImpl}
+	 * @throws MetaborgException
+	 *             when loading fails
+	 */
+	public ILanguageImpl load(FileObject langloc) throws MetaborgException {
+		Set<ILanguageImpl> langs = langDiscoveryService.scanLanguagesInDirectory(langloc);
 
-        // take the first (and only one).
-        return langs.iterator().next();
-    }
+		if (langs == null || langs.isEmpty()) {
+			throw new MetaborgException("Cannot find a language implementation");
+		}
 
-    private FileObject resolveLanguage(String path) {
-        String extension = resourceService.resolveToName(path).getExtension();
-        for (String archive : ARCHIVES) {
-            if (extension.equals(archive)) {
-                return resourceService.resolve(extension + ":" + path + "!/");
-            }
-        }
-        return resourceService.resolve(path);
-    }
+		if (langs.size() > 1) {
+			throw new MetaborgException(
+					"Multiple language implementations found. Please provide an unambiguous path.");
+		}
 
-    private void loadCommands(ILanguageImpl lang) {
-        boolean analyze = lang.hasFacet(AnalyzerFacet.class);
-        CommandBuilder<?> builder = factory.createBuilder(project, lang);
+		// take the first (and only one).
+		return langs.iterator().next();
+	}
 
-        IReplCommand eval, open;
-        Function<ITransformAction, CommandBuilder<TransformResult>> transform;
+	private FileObject resolveLanguage(String path) {
+		String extension = resourceService.resolveToName(path).getExtension();
+		for (String archive : ARCHIVES) {
+			if (extension.equals(archive)) {
+				return resourceService.resolve(extension + ":" + path + "!/");
+			}
+		}
+		return resourceService.resolve(path);
+	}
 
-        invoker.resetCommands();
-        invoker.addCommand("parse", builder.parse().description("Parse the expression").build());
-        if (analyze) {
-            invoker.addCommand("analyze", builder.analyze()
-                .description("Analyze the expression").build());
+	private void loadCommands(ILanguageImpl lang) {
+		boolean analyze = lang.hasFacet(AnalyzerFacet.class);
+		CommandBuilder<?> builder = factory.createBuilder(project, lang);
 
-            eval = builder.evalAnalyzed().description("Evaluate an analyzed expression").build();
-            open = builder.evalAOpen().description("Evaluate and analyze a file").build();
-            transform = builder::transformAnalyzed;
-        } else {
-            eval = builder.evalParsed().description("Evaluate a parsed expression").build();
-            open = builder.evalPOpen().description("Evaluate and parse a file").build();
-            transform = builder::transformParsed;
-        }
-        invoker.addCommand("eval", eval);
-        invoker.addCommand("open", open);
-        invoker.setDefault(eval);
+		IReplCommand eval, open;
+		Function<ITransformAction, CommandBuilder<TransformResult>> transform;
 
-        new TransformVisitor(menuService).getActions(lang).forEach((key, action) ->
-                invoker.addCommand(key, transform.apply(action).description(action.name())
-                        .build()));
-    }
+		invoker.resetCommands();
+		invoker.addCommand("parse", builder.parse().description("Parse the expression").build());
+		if (analyze) {
+			invoker.addCommand("analyze",
+					builder.analyze().description("Analyze the expression").build());
 
-    @Override
-    public IResult execute(String... args) {
-        if (args.length == 0 || args.length > 1) {
-            return new ExceptionResult(new MetaborgException("Syntax: :load <path>"));
-        }
+			eval = builder.evalAnalyzed().description("Evaluate an analyzed expression").build();
+			open = builder.evalAOpen().description("Evaluate and analyze a file").build();
+			transform = builder::transformAnalyzed;
+		} else {
+			eval = builder.evalParsed().description("Evaluate a parsed expression").build();
+			open = builder.evalPOpen().description("Evaluate and parse a file").build();
+			transform = builder::transformParsed;
+		}
+		invoker.addCommand("eval", eval);
+		invoker.addCommand("open", open);
 
-        try {
-            ILanguageImpl lang = load(resolveLanguage(args[0]));
-            loadCommands(lang);
+		invoker.setDefault(eval);
 
-            return (visitor) -> visitor.visitMessage(new StyledText("Loaded language "
-                                                                    + lang.id().toString()));
-        } catch (MetaborgException | MetaborgRuntimeException e) {
-            return new ExceptionResult(e);
-        }
-    }
+		new TransformVisitor(menuService).getActions(lang).forEach((key, action) -> invoker
+				.addCommand(key, transform.apply(action).description(action.name()).build()));
+	}
 
+	@Override
+	public IResult execute(String... args) {
+		if (args.length == 0 || args.length > 1) {
+			return new ExceptionResult(new MetaborgException("Syntax: :load <path>"));
+		}
+
+		try {
+			ILanguageImpl lang = load(resolveLanguage(args[0]));
+			loadCommands(lang);
+
+			return (visitor) -> visitor
+					.visitMessage(new StyledText("Loaded language " + lang.id().toString()));
+		} catch (MetaborgException | MetaborgRuntimeException e) {
+			return new ExceptionResult(e);
+		}
+	}
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
@@ -102,7 +102,7 @@ public interface IFunctionFactory {
      *
      * @param project   The associated {@link IProject}
      * @param lang      The associated {@link ILanguageImpl}
-     * @return          an {@link CommandBuilder}
+     * @return          a {@link CommandBuilder}
      */
     CommandBuilder<?> createBuilder(IProject project, ILanguageImpl lang);
 

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/commands/LanguageCommandTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/commands/LanguageCommandTest.java
@@ -1,9 +1,16 @@
 package org.metaborg.spoofax.shell.commands;
 
 import static org.hamcrest.CoreMatchers.isA;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Arrays;
@@ -46,185 +53,202 @@ import com.google.common.collect.Lists;
  */
 @RunWith(Parameterized.class)
 public class LanguageCommandTest {
-    private final String extension;
+	private final String extension;
 
-    // Constructor mocks
-    @Mock private ILanguageDiscoveryService langDiscoveryService;
-    @Mock private IResourceService resourceService;
-    @Mock private IMenuService menuService;
-    @Mock private ICommandInvoker invoker;
-    @Mock private IFunctionFactory functionFactory;
+	// Constructor mocks
+	@Mock
+	private ILanguageDiscoveryService langDiscoveryService;
+	@Mock
+	private IResourceService resourceService;
+	@Mock
+	private IMenuService menuService;
+	@Mock
+	private ICommandInvoker invoker;
+	@Mock
+	private IFunctionFactory functionFactory;
 
-    @Mock private IProject project;
-    @Mock private ILanguageImpl lang;
-    @Mock private ILanguageComponent langcomp;
+	@Mock
+	private IProject project;
+	@Mock
+	private ILanguageImpl lang;
+	@Mock
+	private ILanguageComponent langcomp;
 
-    @SuppressWarnings("rawtypes")
-    @Mock private CommandBuilder builder;
-    @Mock private IResultVisitor visitor;
-    @Captor private ArgumentCaptor<StyledText> captor;
+	@SuppressWarnings("rawtypes")
+	@Mock
+	private CommandBuilder builder;
+	@Mock
+	private IResultVisitor visitor;
+	@Captor
+	private ArgumentCaptor<StyledText> captor;
 
-    private FileObject langloc;
-    private LanguageCommand langCommand;
+	private FileObject langloc;
+	private LanguageCommand langCommand;
 
-    /**
-     * List the archive types that are tested.
-     *
-     * @return An array of archive extensions.
-     */
-    @Parameters
-    public static Collection<Object[]> archives() {
-        // @formatter.off
-        return Arrays.asList(new Object[][] {
-                { "zip" },
-                { "jar" },
-                { "tar" },
-                { "tgz" },
-                { "tbz2" }
-        });
-        // @formatter.on
-    }
+	/**
+	 * List the archive types that are tested.
+	 *
+	 * @return An array of archive extensions.
+	 */
+	@Parameters
+	public static Collection<Object[]> archives() {
+		// @formatter.off
+		return Arrays
+				.asList(new Object[][] { { "zip" }, { "jar" }, { "tar" }, { "tgz" }, { "tbz2" } });
+		// @formatter.on
+	}
 
-    /**
-     * Instantiate a new {@link LanguageCommandTest}.
-     *
-     * @param archiveExtension
-     *            The archive extension to run the tests with, see {@link #archives()}.
-     */
-    public LanguageCommandTest(String archiveExtension) {
-        this.extension = archiveExtension;
-    }
+	/**
+	 * Instantiate a new {@link LanguageCommandTest}.
+	 *
+	 * @param archiveExtension
+	 *            The archive extension to run the tests with, see
+	 *            {@link #archives()}.
+	 */
+	public LanguageCommandTest(String archiveExtension) {
+		this.extension = archiveExtension;
+	}
 
-    /**
-     * Set up mocks used in the test case.
-     *
-     * @throws FileSystemException
-     *             when resolving the temp file fails
-     * @throws ParseException
-     *             when parsing fails
-     */
-    @Before
-    public void setUp() throws FileSystemException, ParseException {
-        initMocks(this);
-        langloc = VFS.getManager().resolveFile("res:paplj." + this.extension);
-        Mockito.<Iterable<? extends ILanguageImpl>>when(langcomp.contributesTo())
-            .thenReturn(Lists.newArrayList(lang));
-        when(resourceService.resolveToName(anyString())).thenReturn(langloc.getName());
-        when(lang.id()).thenReturn(new LanguageIdentifier("org.borg", "lang",
-                                                          new LanguageVersion(0, 0, 0, "snap")));
+	/**
+	 * Set up mocks used in the test case.
+	 *
+	 * @throws FileSystemException
+	 *             when resolving the temp file fails
+	 * @throws ParseException
+	 *             when parsing fails
+	 */
+	@Before
+	public void setUp() throws FileSystemException, ParseException {
+		initMocks(this);
+		langloc = VFS.getManager().resolveFile("res:paplj." + this.extension);
+		Mockito.<Iterable<? extends ILanguageImpl>>when(langcomp.contributesTo())
+				.thenReturn(Lists.newArrayList(lang));
+		when(resourceService.resolveToName(anyString())).thenReturn(langloc.getName());
+		when(lang.id()).thenReturn(
+				new LanguageIdentifier("org.borg", "lang", new LanguageVersion(0, 0, 0, "snap")));
 
-        when(functionFactory.createBuilder(any(), any())).thenAnswer((invocation) -> builder);
-        when(builder.description(anyString())).thenReturn(builder);
-        when(builder.parse()).thenReturn(builder);
-        when(builder.analyze()).thenReturn(builder);
-        when(builder.transformParsed(any())).thenReturn(builder);
-        when(builder.transformAnalyzed(any())).thenReturn(builder);
-        when(builder.evalParsed()).thenReturn(builder);
-        when(builder.evalAnalyzed()).thenReturn(builder);
-        when(builder.evalPOpen()).thenReturn(builder);
-        when(builder.evalAOpen()).thenReturn(builder);
+		when(functionFactory.createBuilder(any(), any())).thenAnswer((invocation) -> builder);
+		when(builder.description(anyString())).thenReturn(builder);
+		when(builder.parse()).thenReturn(builder);
+		when(builder.analyze()).thenReturn(builder);
+		when(builder.transformParsed(any())).thenReturn(builder);
+		when(builder.transformAnalyzed(any())).thenReturn(builder);
+		when(builder.evalParsed()).thenReturn(builder);
+		when(builder.evalAnalyzed()).thenReturn(builder);
+		when(builder.evalPOpen()).thenReturn(builder);
+		when(builder.evalAOpen()).thenReturn(builder);
 
-        langCommand = new LanguageCommand(langDiscoveryService, resourceService, menuService,
-                                          invoker, functionFactory, project);
-    }
+		langCommand = new LanguageCommand(langDiscoveryService, resourceService, menuService,
+				invoker, functionFactory, project);
+	}
 
-    /**
-     * Verify that the description of a command is never null.
-     */
-    @Test
-    public void testDescription() {
-        assertThat(langCommand.description(), isA(String.class));
-    }
+	/**
+	 * Verify that the description of a command is never null.
+	 */
+	@Test
+	public void testDescription() {
+		assertThat(langCommand.description(), isA(String.class));
+	}
 
-    /**
-     * Test parsing source that results in a valid {@link ISpoofaxParseUnit}.
-     * @throws MetaborgException when language discovery fails
-     * @throws FileSystemException when the file could not be found
-     */
-    @Test(expected = MetaborgException.class)
-    public void testLoadLanguageFail() throws MetaborgException, FileSystemException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet());
+	/**
+	 * Test parsing source that results in a valid {@link ISpoofaxParseUnit}.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 * @throws FileSystemException
+	 *             when the file could not be found
+	 */
+	@Test(expected = MetaborgException.class)
+	public void testLoadLanguageFail() throws MetaborgException, FileSystemException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet());
 
-        langCommand.load(langloc);
-    }
+		langCommand.load(langloc);
+	}
 
-    /**
-     * Test parsing source that results in a valid {@link ISpoofaxParseUnit}.
-     * @throws MetaborgException when language discovery fails
-     * @throws FileSystemException when the file could not be found
-     */
-    @Test
-    public void testLoadLanguage() throws MetaborgException, FileSystemException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
+	/**
+	 * Test parsing source that results in a valid {@link ISpoofaxParseUnit}.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 * @throws FileSystemException
+	 *             when the file could not be found
+	 */
+	@Test
+	public void testLoadLanguage() throws MetaborgException, FileSystemException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
 
-        ILanguageImpl actual = langCommand.load(langloc);
-        verify(langDiscoveryService, times(1)).scanLanguagesInDirectory(langloc);
-        assertEquals(lang, actual);
-    }
+		ILanguageImpl actual = langCommand.load(langloc);
+		verify(langDiscoveryService, times(1)).scanLanguagesInDirectory(langloc);
+		assertEquals(lang, actual);
+	}
 
-    /**
-     * Test execute with invalid input arguments.
-     * @throws MetaborgException when language discovery fails
-     */
-    public void testExecuteInvalidArgs1() throws MetaborgException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
+	/**
+	 * Test execute with invalid input arguments.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 */
+	public void testExecuteInvalidArgs1() throws MetaborgException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
 
-        langCommand.execute().accept(visitor);
-        verify(visitor, times(1)).visitException(any(MetaborgException.class));
-    }
+		langCommand.execute().accept(visitor);
+		verify(visitor, times(1)).visitException(any(MetaborgException.class));
+	}
 
-    /**
-     * Test execute with invalid input arguments.
-     *
-     * @throws MetaborgException
-     *             when language discovery fails
-     */
-    @Test
-    public void testExecuteInvalidArgs2() throws MetaborgException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
+	/**
+	 * Test execute with invalid input arguments.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 */
+	@Test
+	public void testExecuteInvalidArgs2() throws MetaborgException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
 
-        langCommand.execute(new String[] { "", "" }).accept(visitor);
+		langCommand.execute(new String[] { "", "" }).accept(visitor);
 
-        verify(visitor, times(1)).visitException(any(MetaborgException.class));
-    }
+		verify(visitor, times(1)).visitException(any(MetaborgException.class));
+	}
 
-    /**
-     * Test execute with valid input arguments and without AnalysisFacet.
-     *
-     * @throws MetaborgException
-     *             when language discovery fails
-     */
-    @Test
-    public void testExecute() throws MetaborgException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
-        when(menuService.menuItems(any())).thenReturn(Lists.newArrayList());
+	/**
+	 * Test execute with valid input arguments and without AnalysisFacet.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 */
+	@Test
+	public void testExecute() throws MetaborgException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
+		when(menuService.menuItems(any())).thenReturn(Lists.newArrayList());
 
-        String expected = "Loaded language org.borg:lang:0.0.0-snap";
-        langCommand.execute("res:paplj.zip").accept(visitor);
-        verify(visitor, times(1)).visitMessage(captor.capture());
-        verify(invoker, times(1)).resetCommands();
-        verify(invoker, atLeast(1)).addCommand(any(), any());
-        verify(invoker, never()).addCommand(eq("analyze"), any());
-        assertEquals(expected, captor.getValue().toString());
-    }
+		String expected = "Loaded language org.borg:lang:0.0.0-snap";
+		langCommand.execute("res:paplj.zip").accept(visitor);
+		verify(visitor, times(1)).visitMessage(captor.capture());
+		verify(invoker, times(1)).resetCommands();
+		verify(invoker, atLeast(1)).addCommand(any(), any());
+		verify(invoker, never()).addCommand(eq("analyze"), any());
+		assertEquals(expected, captor.getValue().toString());
+	}
 
-    /**
-     * Test execute with valid input arguments and with AnalysisFacet.
-     * @throws MetaborgException when language discovery fails
-     */
-    @Test
-    public void testExecuteAnalyzed() throws MetaborgException {
-        when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
-        when(menuService.menuItems(any())).thenReturn(Lists.newArrayList());
-        when(lang.hasFacet(AnalyzerFacet.class)).thenReturn(true);
+	/**
+	 * Test execute with valid input arguments and with AnalysisFacet.
+	 *
+	 * @throws MetaborgException
+	 *             when language discovery fails
+	 */
+	@Test
+	public void testExecuteAnalyzed() throws MetaborgException {
+		when(langDiscoveryService.scanLanguagesInDirectory(any())).thenReturn(Sets.newSet(lang));
+		when(menuService.menuItems(any())).thenReturn(Lists.newArrayList());
+		when(lang.hasFacet(AnalyzerFacet.class)).thenReturn(true);
 
-        String expected = "Loaded language org.borg:lang:0.0.0-snap";
-        langCommand.execute("res:paplj.zip").accept(visitor);
-        verify(visitor, times(1)).visitMessage(captor.capture());
-        verify(invoker, times(1)).resetCommands();
-        verify(invoker, atLeast(1)).addCommand(any(), any());
-        verify(invoker, times(1)).addCommand(eq("analyze"), any());
-        assertEquals(expected, captor.getValue().toString());
-    }
+		String expected = "Loaded language org.borg:lang:0.0.0-snap";
+		langCommand.execute("res:paplj.zip").accept(visitor);
+		verify(visitor, times(1)).visitMessage(captor.capture());
+		verify(invoker, times(1)).resetCommands();
+		verify(invoker, atLeast(1)).addCommand(any(), any());
+		verify(invoker, times(1)).addCommand(eq("analyze"), any());
+		assertEquals(expected, captor.getValue().toString());
+	}
 
 }

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/output/StyledTextTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/output/StyledTextTest.java
@@ -1,6 +1,8 @@
 package org.metaborg.spoofax.shell.output;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.awt.Color;
 import java.util.Arrays;

--- a/org.metaborg.spoofax.shell.eclipse.externaldeps/pom.xml
+++ b/org.metaborg.spoofax.shell.eclipse.externaldeps/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.metaborg.spoofax.shell.eclipse.externaldeps</artifactId>
   <packaging>bundle</packaging>
@@ -87,4 +84,22 @@
       </plugin>
     </plugins>
   </build>
+
+  <organization>
+    <name>Delft University of Technology</name>
+    <url>http://www.ewi.tudelft.nl/en</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <name>Justin van der Krieken</name>
+      <email>justin@vdkrieken.com</email>
+      <url>https://github.com/justinvdk</url>
+    </developer>
+    <developer>
+      <name>Wouter Smit</name>
+      <email>pathemeous@gmail.com</email>
+      <url>https://github.com/Pathemeous</url>
+    </developer>
+  </developers>
 </project>

--- a/org.metaborg.spoofax.shell.eclipse/pom.xml
+++ b/org.metaborg.spoofax.shell.eclipse/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.metaborg.spoofax.shell.eclipse</artifactId>
   <packaging>eclipse-plugin</packaging>
@@ -14,4 +11,190 @@
     <version>2.3.0-SNAPSHOT</version>
     <relativePath>../../releng/parent/eclipse/plugin</relativePath>
   </parent>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <debug>true</debug>
+        </configuration>
+      </plugin>
+      <!-- Compile Java 8 sources. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-eclipse</artifactId>
+            <version>2.7</version>
+            <scope>compile</scope>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <compilerId>eclipse</compilerId>
+          <source>1.8</source>
+          <target>1.8</target>
+          <debug>true</debug>
+        </configuration>
+      </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <dependencies>
+          <!-- Update Checkstyle to version 6.18 at runtime -->
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.18</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <violationSeverity>warning</violationSeverity>
+          <consoleOutput>false</consoleOutput>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>verify-style</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <!-- Using the latest version here breaks the reporting. -->
+        <!-- dependencies> <dependency> <groupId>net.sourceforge.pmd</groupId> <artifactId>pmd-java</artifactId> 
+          <version>5.4.0</version> </dependency> </dependencies -->
+        <configuration>
+          <verbose>true</verbose>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pmd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>cpd-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <!-- See: http://stackoverflow.com/questions/29594445/cobertura-maven-plugin-conflicts-with-findbugs -->
+          <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>findbugs-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
+      <!-- Checkstyle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../checkstyle.xml</configLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+      </plugin>
+      <!-- JavaDoc -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+      </plugin>
+      <!-- JXR, (optional) dependency of both PMD and Checkstyle in order to xref sources. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+      <!-- PMD -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+        <configuration>
+          <includeTests>true</includeTests>
+          <skipEmptyReport>false</skipEmptyReport>
+        </configuration>
+      </plugin>
+      <!-- FindBugs -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <includeTests>true</includeTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <organization>
+    <name>Delft University of Technology</name>
+    <url>http://www.ewi.tudelft.nl/en</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <name>Justin van der Krieken</name>
+      <email>justin@vdkrieken.com</email>
+      <url>https://github.com/justinvdk</url>
+    </developer>
+    <developer>
+      <name>Wouter Smit</name>
+      <email>pathemeous@gmail.com</email>
+      <url>https://github.com/Pathemeous</url>
+    </developer>
+  </developers>
 </project>

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/Activator.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/Activator.java
@@ -9,65 +9,66 @@ import org.osgi.framework.BundleContext;
 import com.google.inject.Injector;
 
 /**
- * The Activator class controls the plugin's life cycle. It is instantiated by Eclipse automatically. See
- * {@link org.eclipse.core.runtime.Plugin#Plugin()} and {@link AbstractUIPlugin#AbstractUIPlugin()} for more
- * information.
+ * The Activator class controls the plugin's life cycle.
+ * It is instantiated by Eclipse automatically.
+ * See {@link org.eclipse.core.runtime.Plugin#Plugin()} and
+ * {@link AbstractUIPlugin#AbstractUIPlugin()} for more information.
  *
  * Currently its use is to keep track of certain objects that need to be available for the plugin.
  */
 public class Activator extends AbstractUIPlugin {
-    private static Activator plugin;
-    private Injector injector;
+	private static Activator plugin;
+	private Injector injector;
 
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+		injector = SpoofaxPlugin.spoofax().injector.createChildInjector(new EclipseReplModule());
+	}
 
-    @Override public void start(BundleContext context) throws Exception {
-        super.start(context);
-        plugin = this;
-        injector = SpoofaxPlugin.spoofax().injector.createChildInjector(new EclipseReplModule());
-    }
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		injector = null;
+		plugin = null;
+		super.stop(context);
+	}
 
-    @Override public void stop(BundleContext context) throws Exception {
-        injector = null;
-        plugin = null;
-        super.stop(context);
-    }
+	/**
+	 * Return the shared Activator instance.
+	 *
+	 * @return The shared Activator instance.
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
 
+	/**
+	 * Return the shared {@link Injector} instance.
+	 *
+	 * @return The shared {@link Injector} instance.
+	 */
+	public Injector getInjector() {
+		return injector;
+	}
 
-    /**
-     * Return the shared Activator instance.
-     *
-     * @return The shared Activator instance.
-     */
-    public static Activator getDefault() {
-        return plugin;
-    }
+	/**
+	 * Return the plugin's ID.
+	 *
+	 * @return The plugin's ID.
+	 */
+	public static String getPluginID() {
+		return getDefault().getBundle().getSymbolicName();
+	}
 
-    /**
-     * Return the shared {@link Injector} instance.
-     *
-     * @return The shared {@link Injector} instance.
-     */
-    public Injector getInjector() {
-        return injector;
-    }
-
-    /**
-     * Return the plugin's ID.
-     *
-     * @return The plugin's ID.
-     */
-    public static String getPluginID() {
-        return getDefault().getBundle().getSymbolicName();
-    }
-
-    /**
-     * Return an {@link ImageDescriptor} for the image file at the given plugin-relative path.
-     *
-     * @param path
-     *            The plugin-relative path to the image.
-     * @return The {@link ImageDescriptor} for the image at the given path.
-     */
-    public static ImageDescriptor getImageDescriptor(String path) {
-        return imageDescriptorFromPlugin(getPluginID(), path);
-    }
+	/**
+	 * Return an {@link ImageDescriptor} for the image file at the given plugin-relative path.
+	 *
+	 * @param path
+	 *            The plugin-relative path to the image.
+	 * @return The {@link ImageDescriptor} for the image at the given path.
+	 */
+	public static ImageDescriptor getImageDescriptor(String path) {
+		return imageDescriptorFromPlugin(getPluginID(), path);
+	}
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/Activator.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/Activator.java
@@ -17,7 +17,7 @@ import com.google.inject.Injector;
  */
 public class Activator extends AbstractUIPlugin {
     private static Activator plugin;
-    private static Injector injector;
+    private Injector injector;
 
 
     @Override public void start(BundleContext context) throws Exception {
@@ -47,7 +47,7 @@ public class Activator extends AbstractUIPlugin {
      *
      * @return The shared {@link Injector} instance.
      */
-    public static Injector getInjector() {
+    public Injector getInjector() {
         return injector;
     }
 

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
@@ -25,7 +25,7 @@ public class ReplView extends ViewPart {
 
     @Override
     public void createPartControl(Composite parent) {
-        Injector injector = Activator.getInjector();
+        Injector injector = Activator.getDefault().getInjector();
         SashForm page = new SashForm(parent, SWT.VERTICAL | SWT.LEFT_TO_RIGHT);
 
         // Create the display first so it appears on top in the sash.


### PR DESCRIPTION
Adds static tooling to the pom settings, including the original `checkstyle.xml` from the previous group.

Fixes a minor FindBugs violation in `Activator.java`

Autoformats all files with violations, with checkstyle supressions where auto formatter could not be configured to comply with the settings (example in `ReplModule.java` where lines did not get wrapped correctly to max 100 characters).

Development branches should rebase on `develop/shell` after this is merged.