### PR TITLE
Create Editor Services architecture

### DIFF
--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.IRepl;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
+import org.metaborg.spoofax.shell.services.IEditorServices;
 
 import com.google.inject.Inject;
 
@@ -19,6 +20,7 @@ public class ConsoleRepl implements IRepl {
     private final TerminalUserInterface iface;
     private final IDisplay display;
     private boolean running;
+    private final IEditorServices services;
 
     /**
      * Instantiates a new ConsoleRepl.
@@ -29,12 +31,16 @@ public class ConsoleRepl implements IRepl {
      *            The {@link IDisplay} for displaying the results.
      * @param invoker
      *            The {@link ICommandInvoker} for executing user input.
+     * @param services
+     *            The {@link IEditorServices} for requesting editor features.
      */
     @Inject
-    public ConsoleRepl(TerminalUserInterface iface, IDisplay display, ICommandInvoker invoker) {
+	public ConsoleRepl(TerminalUserInterface iface, IDisplay display, ICommandInvoker invoker,
+			IEditorServices services) {
         this.invoker = invoker;
         this.iface = iface;
         this.display = display;
+        this.services = services;
     }
 
     /**
@@ -85,6 +91,11 @@ public class ConsoleRepl implements IRepl {
     @Override
     public ICommandInvoker getInvoker() {
         return this.invoker;
+    }
+
+    @Override
+    public IEditorServices getServices() {
+        return this.services;
     }
 
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
@@ -23,6 +23,7 @@ import org.metaborg.spoofax.shell.functions.InputFunction;
 import org.metaborg.spoofax.shell.functions.OpenInputFunction;
 import org.metaborg.spoofax.shell.functions.PTransformFunction;
 import org.metaborg.spoofax.shell.functions.ParseFunction;
+import org.metaborg.spoofax.shell.functions.StyleFunction;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.invoker.SpoofaxCommandInvoker;
 import org.metaborg.spoofax.shell.output.AnalyzeResult;
@@ -33,6 +34,7 @@ import org.metaborg.spoofax.shell.output.IResultVisitor;
 import org.metaborg.spoofax.shell.output.ISpoofaxTermResult;
 import org.metaborg.spoofax.shell.output.InputResult;
 import org.metaborg.spoofax.shell.output.ParseResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
 import org.metaborg.spoofax.shell.output.TransformResult;
 
 import com.google.common.io.Files;
@@ -89,6 +91,7 @@ public abstract class ReplModule extends AbstractModule {
 	/**
 	 * Binds implementations for the {@link IResultFactory} and the {@link IFunctionFactory}.
 	 */
+	// CHECKSTYLE.OFF: MethodLength - There simply are many function bindings.
 	protected void bindFactories() {
 		install(new FactoryModuleBuilder()
 				.implement(TransformResult.class, Names.named("parsed"),
@@ -116,9 +119,11 @@ public abstract class ReplModule extends AbstractModule {
 				.implement(
 						new TypeLiteral<FailableFunction<ISpoofaxTermResult<?>, EvaluateResult, IResult>>() {
 						}, EvaluateFunction.class)
-				.build(IFunctionFactory.class));
+				.implement(new TypeLiteral<FailableFunction<ParseResult, StyleResult, IResult>>() {
+				}, StyleFunction.class).build(IFunctionFactory.class));
 		// CHECKSTYLE.ON: LineLength
 	}
+	// CHECKSTYLE.ON: MethodLength
 
 	/**
 	 * FIXME: hardcoded project returned here.

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/ReplModule.java
@@ -36,10 +36,15 @@ import org.metaborg.spoofax.shell.output.InputResult;
 import org.metaborg.spoofax.shell.output.ParseResult;
 import org.metaborg.spoofax.shell.output.StyleResult;
 import org.metaborg.spoofax.shell.output.TransformResult;
+import org.metaborg.spoofax.shell.services.IEditorServices;
+import org.metaborg.spoofax.shell.services.IServicesStrategyFactory;
+import org.metaborg.spoofax.shell.services.SpoofaxEditorServices;
+import org.metaborg.spoofax.shell.services.SpoofaxServicesStrategyFactory;
 
 import com.google.common.io.Files;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
@@ -62,6 +67,7 @@ public abstract class ReplModule extends AbstractModule {
 		bindCommands(commandBinder);
 		bindEvalStrategies(evalStrategyBinder);
 		bindFactories();
+		bindEditorServices();
 	}
 
 	/**
@@ -142,4 +148,13 @@ public abstract class ReplModule extends AbstractModule {
 		FileObject resolve = resourceService.resolve(Files.createTempDir());
 		return projectService.create(resolve);
 	}
+
+	/**
+	 * Binds Editor services.
+	 */
+	protected void bindEditorServices() {
+		bind(IEditorServices.class).to(SpoofaxEditorServices.class).in(Singleton.class);
+		bind(IServicesStrategyFactory.class).to(SpoofaxServicesStrategyFactory.class);
+	}
+
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IRepl.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IRepl.java
@@ -6,6 +6,7 @@ import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.ExceptionResult;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.IResultVisitor;
+import org.metaborg.spoofax.shell.services.IEditorServices;
 
 /**
  * This interface defines the evaluation part of a REPL (Read-Eval-Print-Loop). The reason for only
@@ -48,4 +49,11 @@ public interface IRepl {
      * @return The {@link ICommandInvoker}.
      */
     ICommandInvoker getInvoker();
+
+    /**
+     * Return the {@link IEditorServices} used to request editor services.
+     *
+     * @return The {@link IEditorServices}.
+     */
+    IEditorServices getServices();
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/CommandBuilder.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/CommandBuilder.java
@@ -96,40 +96,6 @@ public class CommandBuilder<R extends IResult> {
         this(parent.functionFactory, parent.project, parent.lang, description, function);
     }
 
-    private FailableFunction<String, InputResult, IResult> inputFunction() {
-        return functionFactory.createInputFunction(project, lang);
-    }
-
-    private FailableFunction<String, ParseResult, IResult> parseFunction() {
-        return inputFunction().kleisliCompose(functionFactory.createParseFunction(project, lang));
-    }
-
-    private FailableFunction<String, AnalyzeResult, IResult> analyzeFunction() {
-        return parseFunction().kleisliCompose(functionFactory.createAnalyzeFunction(project, lang));
-    }
-
-    private FailableFunction<String, TransformResult, IResult>
-            pTransformFunction(ITransformAction action) {
-        return parseFunction()
-            .kleisliCompose(functionFactory.createPTransformFunction(project, lang, action));
-    }
-
-    private FailableFunction<String, TransformResult, IResult>
-            aTransformFunction(ITransformAction action) {
-        return analyzeFunction()
-            .kleisliCompose(functionFactory.createATransformFunction(project, lang, action));
-    }
-
-    private FailableFunction<String, EvaluateResult, IResult> pEvaluateFunction() {
-        return parseFunction()
-            .kleisliCompose(functionFactory.createEvaluateFunction(project, lang));
-    }
-
-    private FailableFunction<String, EvaluateResult, IResult> aEvaluateFunction() {
-        return analyzeFunction()
-            .kleisliCompose(functionFactory.createEvaluateFunction(project, lang));
-    }
-
     /**
      * Returns a function that creates an {@link InputResult} from a String.
      *

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/CommandBuilder.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/CommandBuilder.java
@@ -8,6 +8,7 @@ import org.metaborg.core.action.ITransformAction;
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.project.IProject;
 import org.metaborg.spoofax.shell.functions.FailableFunction;
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
 import org.metaborg.spoofax.shell.functions.IFunctionFactory;
 import org.metaborg.spoofax.shell.output.AnalyzeResult;
 import org.metaborg.spoofax.shell.output.EvaluateResult;
@@ -49,6 +50,7 @@ public class CommandBuilder<R extends IResult> {
     private final IFunctionFactory functionFactory;
     private final ILanguageImpl lang;
     private final IProject project;
+    private final FunctionComposer composer;
 
     private final String description;
     private final @Nullable FailableFunction<String[], R, IResult> function;
@@ -56,6 +58,7 @@ public class CommandBuilder<R extends IResult> {
     private CommandBuilder(IFunctionFactory functionFactory, IProject project, ILanguageImpl lang,
                            String description, FailableFunction<String[], R, IResult> function) {
         this.functionFactory = functionFactory;
+        this.composer = functionFactory.createComposer(project, lang);
         this.project = project;
         this.lang = lang;
         this.description = description;
@@ -133,7 +136,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<InputResult> input() {
-        return function(inputFunction());
+        return function(composer.inputFunction());
     }
 
     /**
@@ -142,7 +145,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<ParseResult> parse() {
-        return function(parseFunction());
+        return function(composer.parseFunction());
     }
 
     /**
@@ -151,7 +154,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<AnalyzeResult> analyze() {
-        return function(analyzeFunction());
+        return function(composer.analyzeFunction());
     }
 
     /**
@@ -162,7 +165,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<TransformResult> transformParsed(ITransformAction action) {
-        return function(pTransformFunction(action));
+        return function(composer.pTransformFunction(action));
     }
 
     /**
@@ -173,7 +176,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<TransformResult> transformAnalyzed(ITransformAction action) {
-        return function(aTransformFunction(action));
+        return function(composer.aTransformFunction(action));
     }
 
     /**
@@ -182,7 +185,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<EvaluateResult> evalParsed() {
-        return function(pEvaluateFunction());
+        return function(composer.pEvaluateFunction());
     }
 
     /**
@@ -191,7 +194,7 @@ public class CommandBuilder<R extends IResult> {
      * @return the builder
      */
     public CommandBuilder<EvaluateResult> evalAnalyzed() {
-        return function(aEvaluateFunction());
+        return function(composer.aEvaluateFunction());
     }
 
     /**

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
@@ -13,12 +13,14 @@ import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.menu.IMenuService;
 import org.metaborg.core.project.IProject;
 import org.metaborg.core.resource.IResourceService;
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
 import org.metaborg.spoofax.shell.functions.IFunctionFactory;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.ExceptionResult;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.StyledText;
 import org.metaborg.spoofax.shell.output.TransformResult;
+import org.metaborg.spoofax.shell.services.IEditorServices;
 
 import com.google.inject.Inject;
 
@@ -34,6 +36,7 @@ public class LanguageCommand implements IReplCommand {
 	private final ICommandInvoker invoker;
 	private final IProject project;
 	private final IFunctionFactory factory;
+	private final IEditorServices editorServices;
 
 	/**
 	 * Instantiate a {@link LanguageCommand}. Loads all commands applicable to a language.
@@ -46,6 +49,8 @@ public class LanguageCommand implements IReplCommand {
 	 *            the {@link ICommandInvoker}
 	 * @param factory
 	 *            the {@link IFunctionFactory}
+	 * @param editorServices
+	 *            the {@link IEditorServices}
 	 * @param menuService
 	 *            the {@link IMenuService}
 	 * @param project
@@ -54,12 +59,13 @@ public class LanguageCommand implements IReplCommand {
 	@Inject
 	public LanguageCommand(ILanguageDiscoveryService langDiscoveryService,
 			IResourceService resourceService, IMenuService menuService, ICommandInvoker invoker,
-			IFunctionFactory factory, IProject project) {
+			IEditorServices editorServices, IFunctionFactory factory, IProject project) {
 		// FIXME: don't use the hardcoded @Provides
 		this.langDiscoveryService = langDiscoveryService;
 		this.resourceService = resourceService;
 		this.menuService = menuService;
 		this.invoker = invoker;
+		this.editorServices = editorServices;
 		this.factory = factory;
 		this.project = project;
 	}
@@ -104,6 +110,18 @@ public class LanguageCommand implements IReplCommand {
 		return resourceService.resolve(path);
 	}
 
+	/**
+	 * Initializes the {@link IEditorServices} based on the language
+	 * implementation.
+	 *
+	 * @param lang
+	 *            {@link ILanguageImpl} The language implementation.
+	 */
+	private void loadEditorServices(ILanguageImpl lang) {
+		FunctionComposer composer = factory.createComposer(project, lang);
+		editorServices.load(composer);
+	}
+
 	private void loadCommands(ILanguageImpl lang) {
 		boolean analyze = lang.hasFacet(AnalyzerFacet.class);
 		CommandBuilder<?> builder = factory.createBuilder(project, lang);
@@ -143,6 +161,7 @@ public class LanguageCommand implements IReplCommand {
 		try {
 			ILanguageImpl lang = load(resolveLanguage(args[0]));
 			loadCommands(lang);
+			loadEditorServices(lang);
 
 			return (visitor) -> visitor
 					.visitMessage(new StyledText("Loaded language " + lang.id().toString()));

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
@@ -61,7 +61,7 @@ public abstract class AbstractSpoofaxFunction<In, Success extends ISpoofaxResult
         try {
             return this.applyThrowing(a);
         } catch (Exception e) {
-            return FailOrSuccessResult.failed(new ExceptionResult(e));
+            return FailOrSuccessResult.excepted(new ExceptionResult(e));
         }
     }
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/FunctionComposer.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/FunctionComposer.java
@@ -1,0 +1,116 @@
+package org.metaborg.spoofax.shell.functions;
+
+import org.metaborg.core.action.ITransformAction;
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.project.IProject;
+import org.metaborg.spoofax.shell.output.AnalyzeResult;
+import org.metaborg.spoofax.shell.output.EvaluateResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.InputResult;
+import org.metaborg.spoofax.shell.output.ParseResult;
+import org.metaborg.spoofax.shell.output.TransformResult;
+
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+
+/**
+ * Provides function compositions based on the {@link IFunctionFactory}.
+ *
+ */
+public class FunctionComposer {
+
+    private IFunctionFactory functionFactory;
+    private IProject project;
+    private ILanguageImpl lang;
+
+    /**
+     * Constructs a new {@link FunctionComposer} from the given parameters.
+     *
+     * @param functionFactory
+     *            the {@link IFunctionFactory}
+     * @param project
+     *            the {@link IProject} associated with all created commands
+     * @param lang
+     *            the {@link ILanguageImpl} associated with all created commands
+     */
+    @AssistedInject
+    public FunctionComposer(IFunctionFactory functionFactory, @Assisted IProject project,
+            @Assisted ILanguageImpl lang) {
+                this.functionFactory = functionFactory;
+                this.project = project;
+                this.lang = lang;
+    }
+
+	/**
+	 * Expose the default {@link InputFunction}.
+	 *
+	 * @return {@link InputFunction} - The input function as defined in{@link IFunctionFactory}.
+	 */
+    public FailableFunction<String, InputResult, IResult> inputFunction() {
+        return functionFactory.createInputFunction(project, lang);
+    }
+
+	/**
+	 * Compose the default {@link ParseFunction}.
+	 *
+	 * @return {@link ParseFunction} - The parse function defined in {@link IFunctionFactory}.
+	 */
+    public FailableFunction<String, ParseResult, IResult> parseFunction() {
+        return inputFunction().kleisliCompose(functionFactory.createParseFunction(project, lang));
+    }
+
+	/**
+	 * Compose the default {@link AnalyzeFunction}.
+	 *
+	 * @return {@link AnalyzeFunction} - The analyze function defined in {@link IFunctionFactory}.
+	 */
+    public FailableFunction<String, AnalyzeResult, IResult> analyzeFunction() {
+        return parseFunction().kleisliCompose(functionFactory.createAnalyzeFunction(project, lang));
+    }
+
+	/**
+	 * Compose a {@link PTransformFunction}, which transforms after the parse step.
+	 *
+	 * @param action
+	 *            {@link ITransformAction} - The transformation action
+	 * @return {@link FailableFunction} returning a successful {@link TransformResult}.
+	 */
+    public FailableFunction<String, TransformResult, IResult>
+            pTransformFunction(ITransformAction action) {
+        return parseFunction()
+            .kleisliCompose(functionFactory.createPTransformFunction(project, lang, action));
+    }
+
+	/**
+	 * Compose an {@link ATransformFunction}, which transforms after the analyze step.
+	 *
+	 * @param action
+	 *            {@link ITransformAction} - The transformation action
+	 * @return {@link FailableFunction} returning a successful {@link TransformResult}.
+	 */
+    public FailableFunction<String, TransformResult, IResult>
+            aTransformFunction(ITransformAction action) {
+        return analyzeFunction()
+            .kleisliCompose(functionFactory.createATransformFunction(project, lang, action));
+    }
+
+	/**
+	 * Compose an {@link EvaluateFunction} that evaluates after the parse step.
+	 *
+	 * @return {@link EvaluateFunction} - The evaluation function.
+	 */
+    public FailableFunction<String, EvaluateResult, IResult> pEvaluateFunction() {
+        return parseFunction()
+            .kleisliCompose(functionFactory.createEvaluateFunction(project, lang));
+    }
+
+	/**
+	 * Compose an {@link EvaluateFunction} that evaluates after the analyze step.
+	 *
+	 * @return {@link EvaluateFunction} - The evaluation function.
+	 */
+    public FailableFunction<String, EvaluateResult, IResult> aEvaluateFunction() {
+        return analyzeFunction()
+            .kleisliCompose(functionFactory.createEvaluateFunction(project, lang));
+    }
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/FunctionComposer.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/FunctionComposer.java
@@ -8,6 +8,7 @@ import org.metaborg.spoofax.shell.output.EvaluateResult;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.InputResult;
 import org.metaborg.spoofax.shell.output.ParseResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
 import org.metaborg.spoofax.shell.output.TransformResult;
 
 import com.google.inject.assistedinject.Assisted;
@@ -112,5 +113,19 @@ public class FunctionComposer {
     public FailableFunction<String, EvaluateResult, IResult> aEvaluateFunction() {
         return analyzeFunction()
             .kleisliCompose(functionFactory.createEvaluateFunction(project, lang));
+    }
+
+	/**
+	 * Composes a {@link StyleFunction}, which provides syntax highlighting.
+	 *
+	 * <p>
+	 * The <code>StyleFunction</code> is executed after the parse step.
+	 * </p>
+	 *
+	 * @return {@link StyleFunction} - The style function.
+	 */
+    public FailableFunction<String, StyleResult, IResult> pStyleFunction() {
+        return parseFunction()
+            .kleisliCompose(functionFactory.createStyleFunction(project, lang));
     }
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
@@ -13,6 +13,7 @@ import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.ISpoofaxTermResult;
 import org.metaborg.spoofax.shell.output.InputResult;
 import org.metaborg.spoofax.shell.output.ParseResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
 import org.metaborg.spoofax.shell.output.TransformResult;
 
 /**
@@ -90,6 +91,15 @@ public interface IFunctionFactory {
      */
     FailableFunction<ISpoofaxTermResult<?>, EvaluateResult, IResult>
     createEvaluateFunction(IProject project, ILanguageImpl lang);
+
+    /**
+     * Factory method for creating a {@link StyleFunction}.
+     * @param project   The associated {@link IProject}
+     * @param lang      The associated {@link ILanguageImpl}
+     * @return          an {@link StyleFunction}
+     */
+    FailableFunction<ParseResult, StyleResult, IResult>
+    createStyleFunction(IProject project, ILanguageImpl lang);
 
     /**
      * Factory method for creating a {@link CommandBuilder}.

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/IFunctionFactory.java
@@ -106,4 +106,17 @@ public interface IFunctionFactory {
      */
     CommandBuilder<?> createBuilder(IProject project, ILanguageImpl lang);
 
+    /**
+     * Factory method for creating a {@link FunctionComposer}.
+     *
+     * The composer composes multiple {@link FailableFunction}s by chaining
+     * them.
+     * These composed functions can be used by the {@link CommandBuilder} or
+     * freely in any way to expose them to the front end.
+     *
+     * @param project   The associated {@link IProject}
+     * @param lang      The associated {@link ILanguageImpl}
+     * @return          a {@link FunctionComposer}
+     */
+    FunctionComposer createComposer(IProject project, ILanguageImpl lang);
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/StyleFunction.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/StyleFunction.java
@@ -1,0 +1,88 @@
+package org.metaborg.spoofax.shell.functions;
+
+import org.metaborg.core.context.IContext;
+import org.metaborg.core.context.IContextService;
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.project.IProject;
+import org.metaborg.core.source.ISourceLocation;
+import org.metaborg.core.style.IRegionCategory;
+import org.metaborg.core.style.IRegionStyle;
+import org.metaborg.spoofax.core.style.CategorizerValidator;
+import org.metaborg.spoofax.core.style.ISpoofaxCategorizerService;
+import org.metaborg.spoofax.core.style.ISpoofaxStylerService;
+import org.metaborg.spoofax.core.tracing.ISpoofaxTracingService;
+import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.IResultFactory;
+import org.metaborg.spoofax.shell.output.ParseResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+/**
+ * Provides syntax highlighting in terms of a {@link StyleResult} based on a {@link ParseResult}.
+ */
+public class StyleFunction extends ContextualSpoofaxFunction<ParseResult, StyleResult> {
+
+	private final ISpoofaxStylerService stylerService;
+	private final ISpoofaxCategorizerService categorizer;
+	private final ISpoofaxTracingService tracer;
+
+	/**
+	 * Instantiate the Style Function.
+	 *
+	 * @param stylerService
+	 *            The {@link ISpoofaxStylerService} that applies a certain style to a region.
+	 * @param categorizer
+	 *            The {@link ISpoofaxCategorizerService} that defines regions.
+	 * @param tracer
+	 *            The {@link ISpoofaxTracingService} that connects the source with style regions.
+	 * @param contextService
+	 *            The {@link IContextService} with which to create a new {@link IContext} if
+	 *            necessary.
+	 * @param resultFactory
+	 *            The {@link IResultFactory}.
+	 * @param project
+	 *            The {@link IProject} in which this funcction should operate.
+	 * @param lang
+	 *            The {@link ILanguageImpl} to which this function applies.
+	 */
+	@Inject
+	public StyleFunction(ISpoofaxStylerService stylerService,
+			ISpoofaxCategorizerService categorizer, ISpoofaxTracingService tracer,
+			IContextService contextService, IResultFactory resultFactory,
+			@Assisted IProject project, @Assisted ILanguageImpl lang) {
+		super(contextService, resultFactory, project, lang);
+		this.stylerService = stylerService;
+		this.categorizer = categorizer;
+		this.tracer = tracer;
+	}
+
+	@Override
+	protected FailOrSuccessResult<StyleResult, IResult> applyThrowing(IContext context,
+			ParseResult parseResult) throws Exception {
+
+		ILanguageImpl lang = context.language();
+
+		ISpoofaxParseUnit spoofaxParseUnit = parseResult.unit();
+
+		final Iterable<IRegionCategory<IStrategoTerm>> categories = CategorizerValidator
+				.validate(categorizer.categorize(lang, spoofaxParseUnit));
+
+		Iterable<IRegionStyle<IStrategoTerm>> regions = stylerService
+				.styleParsed(context.language(), categories);
+
+		regions.forEach(region -> {
+			ISourceLocation loc = tracer.location(region.fragment());
+			System.out.println(loc.toString());
+		});
+
+		return FailOrSuccessResult
+				.ofSpoofaxResult(resultFactory.createStyleResult(regions, spoofaxParseUnit));
+
+	}
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessResult.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessResult.java
@@ -72,6 +72,33 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
     }
 
     /**
+     * An excepted result.
+     *
+     * @param <S>
+     * @param <F>
+     */
+    private static final class Excepted<S extends IResult, F extends IResult>
+        extends FailOrSuccessResult<S, F> {
+        private final ExceptionResult result;
+
+        private Excepted(ExceptionResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public void accept(IResultVisitor visitor) {
+            result.accept(visitor);
+        }
+
+        @Override
+        public <NewS extends IResult> FailOrSuccessResult<NewS, F>
+                flatMap(FailableFunction<? super S, NewS, F> failable) {
+            Objects.requireNonNull(failable);
+            return excepted(result);
+        }
+    }
+
+    /**
      * Create an {@link FailOrSuccessResult} that represents a successful result.
      *
      * @param successfulResult
@@ -101,6 +128,24 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
     public static <S extends IResult, F extends IResult> FailOrSuccessResult<S, F>
             failed(F failedResult) {
         return new Failed<>(failedResult);
+    }
+
+    /**
+     * Create an {@link FailOrSuccessResult} that represents an unsuccessful
+     * result (exception).
+     *
+     * @param exceptedResult
+     *            The cause of the exception.
+     * @return The {@link FailOrSuccessResult} with an unsuccessful result.
+     * @param <S>
+     *            The type of the non-existing successful
+     *            {@link ISpoofaxResult}.
+     * @param <F>
+     *            The type of the non-existing failure {@linkplain IResult}.
+     */
+    public static <S extends IResult, F extends IResult> FailOrSuccessResult<S, F> excepted(
+            ExceptionResult exceptedResult) {
+        return new Excepted<>(exceptedResult);
     }
 
     /**

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessResult.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessResult.java
@@ -42,6 +42,11 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
             Objects.requireNonNull(failable);
             return failable.apply(result);
         }
+
+        @Override
+        public void accept(FailOrSuccessVisitor<S, F> visitor) {
+            visitor.visitSuccess(result);
+        }
     }
 
     /**
@@ -69,6 +74,11 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
             Objects.requireNonNull(failable);
             return failed(result);
         }
+
+        @Override
+        public void accept(FailOrSuccessVisitor<S, F> visitor) {
+            visitor.visitFailure(result);
+        }
     }
 
     /**
@@ -95,6 +105,11 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
                 flatMap(FailableFunction<? super S, NewS, F> failable) {
             Objects.requireNonNull(failable);
             return excepted(result);
+        }
+
+        @Override
+        public void accept(FailOrSuccessVisitor<S, F> visitor) {
+            visitor.visitException(result);
         }
     }
 
@@ -172,6 +187,18 @@ public abstract class FailOrSuccessResult<Success extends IResult, Fail extends 
 
     @Override
     public abstract void accept(IResultVisitor visitor);
+
+	/**
+	 * Accept a visitor to dispatch the dynamic type of this class.
+	 *
+	 * <p>
+	 * Such a visitor can define behaviour of the result based on the succesfullness of the request.
+	 * </p>
+	 *
+	 * @param visitor
+	 *            {@link FailOrSuccessVisitor} of the correct generic types.
+	 */
+    public abstract void accept(FailOrSuccessVisitor<Success, Fail> visitor);
 
     /**
      * Maps the given {@link FailableFunction} if this {@link FailOrSuccessResult} represents a

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessVisitor.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/FailOrSuccessVisitor.java
@@ -1,0 +1,42 @@
+package org.metaborg.spoofax.shell.output;
+
+/**
+ * Visitor pattern to dispatch a {@link FailOrSuccessResult} with the specified parametric types.
+ *
+ * The dispatch happens based on the dynamic type of the <code>FailorSuccessResult</code>, not on
+ * its wrapped {@link IResult}.
+ *
+ * @param <Success>
+ *            The type of the wrapped result if it is successful.
+ * @param <Fail>
+ *            The type of the wrapped result if it has failed.
+ */
+public interface FailOrSuccessVisitor<Success extends IResult, Fail extends IResult> {
+
+	/**
+	 * The dispatch for a successful result.
+	 *
+	 * @param result
+	 *            <code>Success</code> - The successful result of the expected
+	 *            type.
+	 */
+	void visitSuccess(Success result);
+
+	/**
+	 * The dispatch for a failed result.
+	 *
+	 * @param result
+	 *            <code>Fail</code> - The failed result of the expected type.
+	 */
+	void visitFailure(Fail result);
+
+	/**
+	 * The dispatch for an exception (that is returned as a result).
+	 *
+	 * @param result
+	 *            <{@link ExceptionResult} - The result containing the
+	 *            exception.
+	 */
+	void visitException(ExceptionResult result);
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/IResultFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/IResultFactory.java
@@ -2,6 +2,7 @@ package org.metaborg.spoofax.shell.output;
 
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.style.IRegionStyle;
 import org.metaborg.core.syntax.IInputUnit;
 import org.metaborg.spoofax.core.syntax.JSGLRParserConfiguration;
 import org.metaborg.spoofax.core.unit.ISpoofaxAnalyzeUnit;
@@ -83,5 +84,19 @@ public interface IResultFactory {
      */
     EvaluateResult createEvaluateResult(ISpoofaxTermResult<?> inputTermResult,
                                         IStrategoTerm result);
+
+
+	/**
+	 * Create an {@link StyleResult} that can be passed to the Repl client.
+	 *
+	 * @param regions
+	 *            Regions that represent the regions and include
+	 *            styling region.
+	 * @param unit
+	 *            a wrapped {@link ISpoofaxParseUnit}
+	 * @return a {@link StyleResult}
+	 */
+	StyleResult createStyleResult(Iterable<IRegionStyle<IStrategoTerm>> regions,
+			ISpoofaxParseUnit unit);
 
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/StyleResult.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/StyleResult.java
@@ -1,0 +1,49 @@
+package org.metaborg.spoofax.shell.output;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.metaborg.core.source.ISourceRegion;
+import org.metaborg.core.style.IRegionStyle;
+import org.metaborg.core.style.RegionStyle;
+import org.metaborg.spoofax.core.stratego.IStrategoCommon;
+import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+/**
+ * Represents a parsed result with iterable style {@link IRegionStyle}s.
+ */
+public class StyleResult extends ParseResult {
+
+	private final Iterable<IRegionStyle<String>> regions;
+
+	/**
+	 * Create a Style Result.
+	 *
+	 * @param common
+	 *            The {@link IStrategoCommon} service.
+	 * @param unit
+	 *            The wrapped {@link ISpoofaxParseUnit}.
+	 * @param regions
+	 *            The {@link IRegionStyle}s in terms of {@link IStrategoTerm}s.
+	 */
+	@Inject
+	public StyleResult(IStrategoCommon common, @Assisted ISpoofaxParseUnit unit,
+			@Assisted Iterable<IRegionStyle<IStrategoTerm>> regions) {
+		super(common, unit);
+		this.regions = StreamSupport.stream(regions.spliterator(), true).map(termRegion -> {
+			ISourceRegion region = termRegion.region();
+			return new RegionStyle<String>(region, termRegion.style(), termRegion.toString());
+
+		}).collect(Collectors.toList());
+	}
+
+	@Override
+	public StyledText styled() {
+		return new StyledText(this.regions);
+	}
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IEditorServices.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IEditorServices.java
@@ -1,0 +1,40 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.client.IRepl;
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.FailOrSuccessVisitor;
+
+/**
+ * Provides an interface to the {@link IRepl} client for requesting editor features.
+ * <p>
+ * The calls in this interface return a {@link FailOrSuccessResult} that can be visited using a
+ * {@link FailOrSuccessVisitor}.
+ * </p>
+ * <p>
+ * The interface implements a Strategy pattern to change its behaviour when a new language is loaded
+ * via {@link #load(FunctionComposer)}.
+ * </p>
+ * <p>
+ * The actual exposed interface of <code>IEditorServices</code> is maintained in its strategy
+ * interface {@link IEditorServicesStrategy}.
+ * This interface only provides the additional ability to change strategies.
+ * </p>
+ */
+public interface IEditorServices extends IEditorServicesStrategy {
+
+	/**
+	 * Loads a language definition that the Editor Services are based on.
+	 *
+	 * <p>
+	 * The services will only return a meaningful result after calling this method for the
+	 * appropriate language.
+	 * </p>
+	 *
+	 * @param composer
+	 *            {@link FunctionComposer} - The Function Composer that was
+	 *            created with the language definition.
+	 */
+	void load(FunctionComposer composer);
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IEditorServicesStrategy.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IEditorServicesStrategy.java
@@ -1,0 +1,37 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+
+/**
+ * Interface for the state of an {@link IEditorServices} class.
+ *
+ * All API that the <code>IEditorServices</code> expose is defined here.
+ */
+public interface IEditorServicesStrategy {
+
+	/**
+	 * Can be used by the client to check whether the services can be requested.
+	 *
+	 * <p>
+	 * Services can only meaningfully be requested when a language is loaded.
+	 * </p>
+	 *
+	 * @return true iff some language has been loaded using
+	 *         {@link IEditorServices#load(FunctionComposer)}.
+	 */
+	boolean isLoaded();
+
+	/**
+	 * Attempts to provide highlighting over the <code>source</code> code.
+	 *
+	 * @param source
+	 *            String - the code that must be highlighted.
+	 * @return {@link FailOrSuccessResult} - A {@link StyleResult} containing a valid highlighting,
+	 *         or a failed result
+	 */
+	FailOrSuccessResult<StyleResult, IResult> highlight(String source);
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IServicesStrategyFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/IServicesStrategyFactory.java
@@ -1,0 +1,11 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+
+public interface IServicesStrategyFactory {
+
+	IEditorServicesStrategy createUnloadedStrategy();
+
+	IEditorServicesStrategy createLoadedStrategy(FunctionComposer composer);
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/LoadedServices.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/LoadedServices.java
@@ -1,0 +1,39 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+
+/**
+ * The strategy for {@link IEditorServices} when a language is loaded.
+ */
+public class LoadedServices implements IEditorServicesStrategy {
+
+	private final FunctionComposer composer;
+
+	/**
+	 * Initializes the behaviour of a functional {@link IEditorServices}.
+	 *
+	 * <p>
+	 * The behaviour is based on the provided <code>IFunctionComposer</code>.
+	 * </p>
+	 *
+	 * @param composer
+	 *            {@link FunctionComposer}
+	 *            The language implementation that is used.
+	 */
+	protected LoadedServices(FunctionComposer composer) {
+		this.composer = composer;
+	}
+
+	@Override
+	public boolean isLoaded() {
+		return true;
+	}
+
+	@Override
+	public FailOrSuccessResult<StyleResult, IResult> highlight(String source) {
+		return composer.pStyleFunction().apply(source);
+	}
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/ServiceUnavailableException.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/ServiceUnavailableException.java
@@ -1,0 +1,26 @@
+package org.metaborg.spoofax.shell.services;
+
+/**
+ * Exception to be thrown when {@link IEditorServices} cannot return the requested service.
+ */
+public class ServiceUnavailableException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+	private final String service;
+
+	/**
+	 * Create a new exception.
+	 *
+	 * @param service
+	 *            String - The service that could not be provided.
+	 */
+	public ServiceUnavailableException(String service) {
+		this.service = service;
+	}
+
+	@Override
+	public String getMessage() {
+		return "Could not provide the following service: " + service;
+	}
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/SpoofaxEditorServices.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/SpoofaxEditorServices.java
@@ -1,0 +1,49 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+
+import com.google.inject.Inject;
+
+/**
+ * Default implementation of {@link IEditorServices}.
+ */
+public class SpoofaxEditorServices implements IEditorServices {
+
+	private final IServicesStrategyFactory strategyfactory;
+	private IEditorServicesStrategy strategy;
+
+	/**
+	 * Instantiates a new SpoofaxEditorServices.
+	 *
+	 * The services will not return any meaningful results until a language has
+	 * been loaded with {@link #load(FunctionComposer)}.
+	 *
+	 * @param initialStrategy
+	 *            {@link IEditorServicesStrategy} The injected 'unloaded' strategy that is used.
+	 * @param loadedStrategy
+	 *            {@link IEditorServicesStrategy} The injected 'loaded' strategy that is used.
+	 */
+	@Inject
+	public SpoofaxEditorServices(IServicesStrategyFactory strategyfactory) {
+		this.strategyfactory = strategyfactory;
+		this.strategy = strategyfactory.createUnloadedStrategy();
+	}
+
+	@Override
+	public FailOrSuccessResult<StyleResult, IResult> highlight(String source) {
+		return strategy.highlight(source);
+	}
+
+	@Override
+	public void load(FunctionComposer composer) {
+		strategy = strategyfactory.createLoadedStrategy(composer);
+	}
+
+	@Override
+	public boolean isLoaded() {
+		return strategy.isLoaded();
+	}
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/SpoofaxServicesStrategyFactory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/SpoofaxServicesStrategyFactory.java
@@ -1,0 +1,17 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+
+public class SpoofaxServicesStrategyFactory implements IServicesStrategyFactory {
+
+	@Override
+	public IEditorServicesStrategy createUnloadedStrategy() {
+		return new UnloadedServices();
+	}
+
+	@Override
+	public IEditorServicesStrategy createLoadedStrategy(FunctionComposer composer) {
+		return new LoadedServices(composer);
+	}
+
+}

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/UnloadedServices.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/services/UnloadedServices.java
@@ -1,0 +1,42 @@
+package org.metaborg.spoofax.shell.services;
+
+import org.metaborg.spoofax.shell.output.ExceptionResult;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+
+/**
+ * The strategy for {@link IEditorServices} when no language is loaded.
+ *
+ * <p>
+ * All method calls (that require a language definition) should return a negative
+ * {@link FailOrSuccessResult} containing a {@link ServiceUnavailableException}.
+ * </p>
+ */
+public class UnloadedServices implements IEditorServicesStrategy {
+
+	/**
+	 * Protected constructor hides the strategy from other packages.
+	 */
+	protected UnloadedServices() {
+	}
+
+	/**
+	 * Creates an exception that can be used to return to the client as a failure.
+	 *
+	 * @return {@link ExceptionResult} - An exception about the language being unavailable.
+	 */
+	private ExceptionResult createException(String service) {
+		return new ExceptionResult(new ServiceUnavailableException(service));
+	}
+
+	@Override
+	public boolean isLoaded() {
+		return false;
+	}
+
+	@Override
+	public FailOrSuccessResult<StyleResult, IResult> highlight(String source) {
+		return FailOrSuccessResult.excepted(createException("Syntax Highlighting"));
+	}
+}

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/commands/LanguageCommandTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/commands/LanguageCommandTest.java
@@ -40,6 +40,7 @@ import org.metaborg.spoofax.shell.functions.IFunctionFactory;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.IResultVisitor;
 import org.metaborg.spoofax.shell.output.StyledText;
+import org.metaborg.spoofax.shell.services.IEditorServices;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -64,6 +65,8 @@ public class LanguageCommandTest {
 	private IMenuService menuService;
 	@Mock
 	private ICommandInvoker invoker;
+	@Mock
+	private IEditorServices editorServices;
 	@Mock
 	private IFunctionFactory functionFactory;
 
@@ -139,7 +142,7 @@ public class LanguageCommandTest {
 		when(builder.evalAOpen()).thenReturn(builder);
 
 		langCommand = new LanguageCommand(langDiscoveryService, resourceService, menuService,
-				invoker, functionFactory, project);
+				invoker, editorServices, functionFactory, project);
 	}
 
 	/**

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/AnalyzeFunctionTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/AnalyzeFunctionTest.java
@@ -92,6 +92,9 @@ public class AnalyzeFunctionTest {
         );
         when(functionFactory.createAnalyzeFunction(any(), any())).thenReturn(analyzeFunction);
 
+        FunctionComposer composer = new FunctionComposer(functionFactory, project, lang);
+        when(functionFactory.createComposer(any(), any())).thenReturn(composer);
+
         when(parseResult.context()).thenReturn(Optional.empty());
         when(analyzeResult.unit()).thenReturn(analyzeUnit);
         when(resultFactory.createAnalyzeResult(any())).thenReturn(analyzeResult);

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/EvaluateFunctionTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/EvaluateFunctionTest.java
@@ -195,6 +195,9 @@ public class EvaluateFunctionTest {
             .thenReturn((input) -> FailOrSuccessResult.successful(analyzeResult));
 
         when(functionFactory.createEvaluateFunction(any(), any())).thenReturn(pEvalFunction);
+
+        FunctionComposer composer = new FunctionComposer(functionFactory, project, lang);
+        when(functionFactory.createComposer(any(), any())).thenReturn(composer);
     }
 
     /**

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/InputFunctionTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/InputFunctionTest.java
@@ -77,6 +77,9 @@ public class InputFunctionTest {
         when(inputResult.unit()).thenReturn(inputUnit);
         when(resultFactory.createInputResult(any(), any(), any(), any())).thenReturn(inputResult);
 
+        FunctionComposer composer = new FunctionComposer(functionFactory, project, lang);
+        when(functionFactory.createComposer(any(), any())).thenReturn(composer);
+
         when(lang.facet(ShellFacet.class)).thenReturn(facet);
 
         inputCommand = new CommandBuilder<>(functionFactory, project, lang)

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/ParseFunctionTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/ParseFunctionTest.java
@@ -83,6 +83,9 @@ public class ParseFunctionTest {
         );
         when(functionFactory.createParseFunction(any(), any())).thenReturn(parseFunction);
 
+        FunctionComposer composer = new FunctionComposer(functionFactory, project, lang);
+        when(functionFactory.createComposer(any(), any())).thenReturn(composer);
+
         when(inputResult.unit()).thenReturn(inputUnit);
         when(parseResult.unit()).thenReturn(parseUnit);
         when(resultFactory.createParseResult(any())).thenReturn(parseResult);

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/TransformFunctionTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/functions/TransformFunctionTest.java
@@ -177,6 +177,9 @@ public class TransformFunctionTest {
             .thenReturn(pTransformFunction);
         when(functionFactory.createATransformFunction(any(), any(), any()))
             .thenReturn(aTransformFunction);
+
+        FunctionComposer composer = new FunctionComposer(functionFactory, project, lang);
+        when(functionFactory.createComposer(any(), any())).thenReturn(composer);
     }
 
     /**

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/LoadedServicesTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/LoadedServicesTest.java
@@ -1,0 +1,70 @@
+package org.metaborg.spoofax.shell.services;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.metaborg.spoofax.shell.functions.FailableFunction;
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+import org.metaborg.spoofax.shell.services.IEditorServicesStrategy;
+import org.metaborg.spoofax.shell.services.LoadedServices;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests for {@link LoadedServices}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LoadedServicesTest {
+
+    private IEditorServicesStrategy strategy;
+
+    @Mock
+    private FunctionComposer composer;
+    @Mock
+    private FailableFunction<String, StyleResult, IResult> highlightFunction;
+
+    /**
+     * Initialize all required function composition stubs and a fresh instance
+     * of the class under test.
+     */
+    @Before
+    public void setUp() {
+        this.strategy = new LoadedServices(composer);
+        when(composer.pStyleFunction()).thenReturn(highlightFunction);
+    }
+
+    /**
+     * Assert that the constructor works.
+     */
+    @Test
+    public void testLoadedServices() {
+        assertNotNull(strategy);
+    }
+
+    /**
+     * Assert that the LoadedServices return <code>true</code>.
+     */
+    @Test
+    public void testIsLoaded() {
+        assertTrue(strategy.isLoaded());
+    }
+
+    /**
+     * Test that the right stubbed function composition is called and that it is
+     * applied with the right source.
+     */
+    @Test
+    public void testHighlight() {
+        final String source = "SomeSource";
+        strategy.highlight(source);
+        verify(highlightFunction).apply(source);
+    }
+
+}

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/SpoofaxEditorServicesTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/SpoofaxEditorServicesTest.java
@@ -1,0 +1,116 @@
+package org.metaborg.spoofax.shell.services;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.metaborg.spoofax.shell.functions.FunctionComposer;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Test the default implementation of {@link IEditorServices}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SpoofaxEditorServicesTest {
+
+	private SpoofaxEditorServices services;
+
+	@Mock
+	private FunctionComposer composer;
+	@Mock
+	private IServicesStrategyFactory factory;
+	@Mock
+	private UnloadedServices unloaded;
+	@Mock
+	private LoadedServices loaded;
+	@Mock
+	private FailOrSuccessResult<StyleResult, IResult> highlightResult;
+
+	/**
+	 * Set up instance of the class under test.
+	 */
+	@Before
+	public void setUp() {
+		when(factory.createUnloadedStrategy()).thenReturn(unloaded);
+		when(factory.createLoadedStrategy(any())).thenReturn(loaded);
+		services = new SpoofaxEditorServices(factory);
+	}
+
+	/**
+	 * Test that Services are constructed with 'unloaded' behaviour.
+	 */
+	@Test
+	public void testSpoofaxEditorServices() {
+		verify(factory).createUnloadedStrategy();
+	}
+
+	/**
+	 * Tests that the Services' strategy is correctly replaced when a language
+	 * is loaded.
+	 */
+	@Test
+	public void testLoad() {
+		services.load(composer);
+		verify(factory).createLoadedStrategy(composer);
+		services.isLoaded();
+		verify(loaded).isLoaded();
+	}
+
+	/**
+	 * Tests the strategy delegation of
+	 * {@link IEditorServices#highlight(String)} to the unloaded strategy.
+	 */
+	@Test
+	public void testHighlightUnloaded() {
+		final String testSource = "test";
+		services.highlight(testSource);
+		verifyZeroInteractions(loaded);
+		verify(unloaded).highlight(testSource);
+	}
+
+	/**
+	 * Tests the strategy delegation of
+	 * {@link IEditorServices#highlight(String)} to the loaded strategy.
+	 */
+	@Test
+	public void testHighlightLoaded() {
+		final String testSource = "test";
+		services.load(composer);
+		services.highlight(testSource);
+		verifyZeroInteractions(unloaded);
+		verify(loaded).highlight(testSource);
+	}
+
+	/**
+	 * Tests the strategy delegation of {@link IEditorServices#isLoaded()} as well as the unloaded
+	 * return value (false).
+	 */
+	@Test
+	public void testIsLoadedFalse() {
+		services.isLoaded();
+		verify(unloaded).isLoaded();
+	}
+
+	/**
+	 * Tests the strategy delegation of {@link IEditorServices#isLoaded()} as well as the loaded
+	 * return value (true).
+	 */
+	@Test
+	public void testIsLoadedTrue() {
+		FunctionComposer composer = mock(FunctionComposer.class);
+		services.load(composer);
+		services.isLoaded();
+		verifyZeroInteractions(unloaded);
+		verify(loaded).isLoaded();
+	}
+
+}

--- a/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/UnloadedServicesTest.java
+++ b/org.metaborg.spoofax.shell.core/src/test/java/org/metaborg/spoofax/shell/services/UnloadedServicesTest.java
@@ -1,0 +1,59 @@
+package org.metaborg.spoofax.shell.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.metaborg.spoofax.shell.output.ExceptionResult;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.services.IEditorServicesStrategy;
+import org.metaborg.spoofax.shell.services.UnloadedServices;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests for {@link UnloadedServices}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UnloadedServicesTest {
+
+	private IEditorServicesStrategy strategy;
+
+	/**
+	 * Set up instance of the class under test.
+	 */
+	@Before
+	public void setUp() {
+		strategy = new UnloadedServices();
+	}
+
+	/**
+	 * Test correct instantiation.
+	 */
+	@Test
+	public void testUnloadedServices() {
+		assertNotNull(strategy);
+	}
+
+	/**
+	 * Test correct flag for the loaded state.
+	 */
+	@Test
+	public void testIsLoaded() {
+		assertFalse(strategy.isLoaded());
+	}
+
+	/**
+	 * Test that highlighting returns an exception.
+	 */
+	@Test
+	public void testHighlight() {
+		System.out.println(strategy.highlight("someSource").getClass());
+		assertEquals(FailOrSuccessResult.excepted(mock(ExceptionResult.class)).getClass(),
+				strategy.highlight("someSource").getClass());
+	}
+
+}

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/EclipseReplModule.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/EclipseReplModule.java
@@ -7,6 +7,10 @@ import org.metaborg.spoofax.shell.client.eclipse.ColorManager;
 import org.metaborg.spoofax.shell.client.eclipse.commands.ExitCommand;
 import org.metaborg.spoofax.shell.client.eclipse.impl.IWidgetFactory;
 import org.metaborg.spoofax.shell.commands.IReplCommand;
+import org.metaborg.spoofax.shell.services.IEditorServices;
+import org.metaborg.spoofax.shell.services.IServicesStrategyFactory;
+import org.metaborg.spoofax.shell.services.SpoofaxEditorServices;
+import org.metaborg.spoofax.shell.services.SpoofaxServicesStrategyFactory;
 
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
@@ -18,6 +22,7 @@ import com.google.inject.multibindings.MapBinder;
 public class EclipseReplModule extends ReplModule {
     @Override protected void configure() {
         super.configure();
+		bindEditorServices();
 
         // Bind simple project service for creating a fake project
         bind(ISimpleProjectService.class).to(SimpleProjectService.class).in(Singleton.class);
@@ -32,4 +37,13 @@ public class EclipseReplModule extends ReplModule {
         super.bindCommands(commandBinder);
         commandBinder.addBinding("exit").to(ExitCommand.class);
     }
+
+	/**
+	 * Binds Editor services.
+	 */
+	protected void bindEditorServices() {
+		bind(IEditorServices.class).to(SpoofaxEditorServices.class).in(Singleton.class);
+		bind(IServicesStrategyFactory.class).to(SpoofaxServicesStrategyFactory.class);
+	}
+
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/EclipseReplModule.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/EclipseReplModule.java
@@ -22,7 +22,6 @@ import com.google.inject.multibindings.MapBinder;
 public class EclipseReplModule extends ReplModule {
     @Override protected void configure() {
         super.configure();
-		bindEditorServices();
 
         // Bind simple project service for creating a fake project
         bind(ISimpleProjectService.class).to(SimpleProjectService.class).in(Singleton.class);
@@ -37,13 +36,5 @@ public class EclipseReplModule extends ReplModule {
         super.bindCommands(commandBinder);
         commandBinder.addBinding("exit").to(ExitCommand.class);
     }
-
-	/**
-	 * Binds Editor services.
-	 */
-	protected void bindEditorServices() {
-		bind(IEditorServices.class).to(SpoofaxEditorServices.class).in(Singleton.class);
-		bind(IServicesStrategyFactory.class).to(SpoofaxServicesStrategyFactory.class);
-	}
 
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/EclipseUtil.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/EclipseUtil.java
@@ -1,0 +1,65 @@
+package org.metaborg.spoofax.shell.client.eclipse;
+
+import java.awt.Color;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.RGB;
+import org.metaborg.core.style.IStyle;
+
+/**
+ * Utility methods for the Eclipse Client.
+ */
+public final class EclipseUtil {
+
+	private EclipseUtil() {
+		//Empty private constructor to prevent instantiation.
+	}
+
+	/**
+	 * Create an SWT {@link StyleRange} based on the MetaBorg styling at the provided offset.
+	 *
+	 * @param colorManager
+	 *            {@link ColorManager} to manage SWT colors.
+	 * @param style
+	 *            {@link IStyle} The MetaBorg styling.
+	 * @param offset
+	 *            int - The offset to start.
+	 * @param length
+	 *            int - The length of the styling.
+	 * @return {@link StyleRange} - SWT Styling.
+	 */
+	public static StyleRange style(ColorManager colorManager, IStyle style, int offset,
+			int length) {
+		StyleRange styleRange = new StyleRange();
+
+		styleRange.start = offset;
+		styleRange.length = length;
+		if (style.color() != null) {
+			styleRange.foreground = colorManager.getColor(awtToRGB(style.color()));
+		}
+		if (style.backgroundColor() != null) {
+			styleRange.background = colorManager.getColor(awtToRGB(style.backgroundColor()));
+		}
+		if (style.bold()) {
+			styleRange.fontStyle |= SWT.BOLD;
+		}
+		if (style.italic()) {
+			styleRange.fontStyle |= SWT.ITALIC;
+		}
+
+		return styleRange;
+	}
+
+	/**
+	 * Convert an AWT {@link Color} to SWT {@link RGB}.
+	 *
+	 * @param awt
+	 *            {@link Color} The AWT color instance.
+	 * @return {@link RGB} The SWT color instance.
+	 */
+	public static RGB awtToRGB(Color awt) {
+		return new RGB(awt.getRed(), awt.getGreen(), awt.getBlue());
+	}
+
+}

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
@@ -37,8 +37,10 @@ public class ReplView extends ViewPart {
         page.setWeights(new int[] { DISPLAYWEIGHT, EDITORWEIGHT });
 
         // Instantiate the REPL and add it as observer of the editor.
-        EclipseRepl repl = factory.createRepl(display);
-        this.editor.asObservable().subscribe(repl);
+        EclipseRepl repl = factory.createRepl(display, editor);
+
+        this.editor.asObservable(false).subscribe(repl.getLineInputObserver());
+        this.editor.asObservable(true).subscribe(repl.getLiveInputObserver());
 
         // Retrieve the color manager so that it can be disposed of when the view is closed.
         this.colorManager = injector.getInstance(ColorManager.class);

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseDisplay.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseDisplay.java
@@ -1,7 +1,5 @@
 package org.metaborg.spoofax.shell.client.eclipse.impl;
 
-import java.awt.Color;
-
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -10,11 +8,11 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.TextViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.metaborg.core.style.IStyle;
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.eclipse.ColorManager;
+import org.metaborg.spoofax.shell.client.eclipse.EclipseUtil;
 import org.metaborg.spoofax.shell.output.StyledText;
 
 import com.google.inject.assistedinject.Assisted;
@@ -75,34 +73,6 @@ public class EclipseDisplay implements IDisplay {
         }
     }
 
-    private void style(IStyle style, int offset, int length) {
-        if (style != null) {
-            StyleRange styleRange = new StyleRange();
-
-            styleRange.start = offset;
-            styleRange.length = length;
-            if (style.color() != null) {
-                styleRange.foreground = this.colorManager.getColor(awtToRGB(style.color()));
-            }
-            if (style.backgroundColor() != null) {
-                styleRange.background =
-                    this.colorManager.getColor(awtToRGB(style.backgroundColor()));
-            }
-            if (style.bold()) {
-                styleRange.fontStyle |= SWT.BOLD;
-            }
-            if (style.italic()) {
-                styleRange.fontStyle |= SWT.ITALIC;
-            }
-
-            output.getTextWidget().setStyleRange(styleRange);
-        }
-    }
-
-    private RGB awtToRGB(Color awt) {
-        return new RGB(awt.getRed(), awt.getGreen(), awt.getBlue());
-    }
-
     @Override
     public void displayStyledText(StyledText text) {
         IDocument doc = getDocument();
@@ -111,7 +81,17 @@ public class EclipseDisplay implements IDisplay {
             int offset = doc.getLength();
 
             append(doc, offset, e.fragment());
-            style(e.style(), offset, e.region().length());
+
+            IStyle style = e.style();
+            if (style != null) {
+                StyleRange styleRange = EclipseUtil.style(
+                        colorManager,
+                        e.style(),
+                        offset,
+                        e.region().length());
+
+                output.getTextWidget().setStyleRange(styleRange);
+            }
         });
 
         if (doc != null) {

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
@@ -5,14 +5,14 @@ import java.util.Observer;
 
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.metaborg.spoofax.shell.client.IInputHistory;
 import org.metaborg.spoofax.shell.client.InputHistory;
@@ -35,11 +35,12 @@ import rx.Subscriber;
  *
  * Note that this class should always be run in and accessed from the UI thread!
  */
-public class EclipseEditor extends KeyAdapter implements ModifyListener {
+public class EclipseEditor extends KeyAdapter implements IDocumentListener {
     private final IInputHistory history;
     private final SourceViewer input;
     private final IDocument document;
-    private final List<Subscriber<? super String>> observers;
+    private final List<Subscriber<? super String>> lineObservers;
+    private final List<Subscriber<? super String>> liveObservers;
 
     /**
      * Instantiates a new EclipseEditor.
@@ -59,7 +60,9 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
         this.input.getTextWidget().setAlwaysShowScrollBars(false);
         this.input.setDocument(document);
         this.input.getTextWidget().addKeyListener(this);
-        this.observers = Lists.newArrayList();
+        this.document.addDocumentListener(this);
+        this.lineObservers = Lists.newArrayList();
+        this.liveObservers = Lists.newArrayList();
     }
 
     /**
@@ -74,11 +77,18 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
      * {@link KeyListener} functions when some notable key presses (e.g. Enter to submit input)
      * occur.
      *
+     * @param live
+     *            - boolean denoting whether the observer subscribes to live or normal input.
      * @return A new {@link Observable} from this editor.
      */
-    public Observable<String> asObservable() {
-        return Observable
-            .create((Observable.OnSubscribe<String>) EclipseEditor.this.observers::add);
+    public Observable<String> asObservable(boolean live) {
+        return Observable.create((o) -> {
+            if (live) {
+                EclipseEditor.this.liveObservers.add(o);
+            } else {
+                EclipseEditor.this.lineObservers.add(o);
+            }
+        });
     }
 
     /**
@@ -88,12 +98,13 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
      *            The {@link Subscriber} to remove.
      */
     public void removeObserver(Subscriber<? super String> observer) {
-        this.observers.remove(observer);
+        this.lineObservers.remove(observer);
+        this.liveObservers.remove(observer);
     }
 
-    private String removeLastNewline(String text) {
+    private static String removeLastNewline(String text) {
         int length = text.length() - 1;
-        if (text.charAt(length) == '\n') {
+        if (length > 0 && text.charAt(length) == '\n') {
             text = text.substring(0, length);
         }
         return text;
@@ -101,7 +112,7 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
 
     private void enterPressed() {
         String text = removeLastNewline(document.get());
-        this.observers.forEach(o -> o.onNext(text));
+        this.lineObservers.forEach(o -> o.onNext(text));
         if (text.length() > 0) {
             this.history.append(text);
         }
@@ -139,8 +150,16 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
     }
 
     @Override
-    public void modifyText(ModifyEvent event) {
-        // TODO: text has been modified, send it to get syntax highlighting.
+    public void documentAboutToBeChanged(DocumentEvent event) {
+        // TODO Auto-generated method stub
     }
+
+    @Override
+    public void documentChanged(DocumentEvent event) {
+        // TODO: possibly wait a bit instead of spamming the observers with every possible change
+        liveObservers.forEach(o -> {
+            o.onNext(document.get());
+        });
+	}
 
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
@@ -10,12 +10,18 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.widgets.Composite;
+import org.metaborg.core.source.ISourceRegion;
+import org.metaborg.core.style.IStyle;
 import org.metaborg.spoofax.shell.client.IInputHistory;
 import org.metaborg.spoofax.shell.client.InputHistory;
+import org.metaborg.spoofax.shell.client.eclipse.ColorManager;
+import org.metaborg.spoofax.shell.client.eclipse.EclipseUtil;
+import org.metaborg.spoofax.shell.output.StyleResult;
 
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
@@ -41,6 +47,7 @@ public class EclipseEditor extends KeyAdapter implements IDocumentListener {
     private final IDocument document;
     private final List<Subscriber<? super String>> lineObservers;
     private final List<Subscriber<? super String>> liveObservers;
+    private final ColorManager colorManager;
 
     /**
      * Instantiates a new EclipseEditor.
@@ -50,9 +57,12 @@ public class EclipseEditor extends KeyAdapter implements IDocumentListener {
      * @param parent
      *            A {@link Composite} control which will be the parent of this EclipseEditor.
      *            (cannot be {@code null}).
+     * @param colorManager
+     *            A {@link ColorManager} to manage SWT colours.
      */
     @AssistedInject
-    public EclipseEditor(IInputHistory history, @Assisted Composite parent) {
+	public EclipseEditor(IInputHistory history, @Assisted Composite parent,
+			ColorManager colorManager) {
         this.history = history;
         this.document = new Document();
         this.input = new SourceViewer(parent, null, SWT.BORDER | SWT.MULTI);
@@ -61,6 +71,9 @@ public class EclipseEditor extends KeyAdapter implements IDocumentListener {
         this.input.setDocument(document);
         this.input.getTextWidget().addKeyListener(this);
         this.document.addDocumentListener(this);
+
+        this.colorManager = colorManager;
+
         this.lineObservers = Lists.newArrayList();
         this.liveObservers = Lists.newArrayList();
     }
@@ -161,5 +174,30 @@ public class EclipseEditor extends KeyAdapter implements IDocumentListener {
             o.onNext(document.get());
         });
 	}
+
+    /**
+	 * Applies a {@link StyleResult} to the input text.
+	 *
+	 * @param styleResult
+	 *            {@link StyleResult} containing the styling for the text.
+	 */
+    public void applyStyle(StyleResult styleResult) {
+        styleResult.styled().getSource().forEach(regionStyle -> {
+            ISourceRegion region = regionStyle.region();
+            IStyle style = regionStyle.style();
+            if (style != null) {
+                StyleRange styleRange = EclipseUtil.style(
+                        colorManager,
+                        style,
+                        region.startOffset(),
+                        region.length());
+                try {
+                    input.getTextWidget().setStyleRange(styleRange);
+                } catch (Exception e) { //NOPMD - Temporary: nothing meaningful can be done anyway.
+                    //TODO: validate the styleRange before setting
+                }
+            }
+        });
+    }
 
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
@@ -13,7 +13,11 @@ import org.metaborg.core.style.Style;
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.IRepl;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
+import org.metaborg.spoofax.shell.output.ExceptionResult;
+import org.metaborg.spoofax.shell.output.FailOrSuccessResult;
+import org.metaborg.spoofax.shell.output.FailOrSuccessVisitor;
 import org.metaborg.spoofax.shell.output.IResult;
+import org.metaborg.spoofax.shell.output.StyleResult;
 import org.metaborg.spoofax.shell.output.StyledText;
 import org.metaborg.spoofax.shell.services.IEditorServices;
 
@@ -226,6 +230,7 @@ public class EclipseRepl implements IRepl {
 
 		@Override
 		public void onNext(String input) {
+			runSyntaxHighlighting(input);
 		}
 
     }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
@@ -15,6 +15,7 @@ import org.metaborg.spoofax.shell.client.IRepl;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.StyledText;
+import org.metaborg.spoofax.shell.services.IEditorServices;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -33,6 +34,7 @@ public class EclipseRepl implements IRepl {
     private final IDisplay display;
     private final EclipseEditor editor; //NOPMD - Will be used in later commits.
     private final ICommandInvoker invoker;
+    private final IEditorServices services;
     private final ExecutorService pool;
 
     private final Observer<String> lineInputObserver;
@@ -43,17 +45,20 @@ public class EclipseRepl implements IRepl {
      *
      * @param invoker
      *            The {@link ICommandInvoker} for executing user input.
+     * @param services
+     *            The {@link IEditorServices} for requesting editor features.
      * @param display
      *            The {@link IDisplay} to send results to.
      * @param editor
      *            The {@link EclipseEditor} to send input results to.
      */
     @AssistedInject
-	public EclipseRepl(ICommandInvoker invoker, @Assisted IDisplay display,
-			@Assisted EclipseEditor editor) {
+	public EclipseRepl(ICommandInvoker invoker, IEditorServices services,
+			@Assisted IDisplay display, @Assisted EclipseEditor editor) {
         this.display = display;
         this.editor = editor;
         this.invoker = invoker;
+        this.services = services;
         pool = Executors.newSingleThreadExecutor();
         this.lineInputObserver = new LineInputObserver();
         this.liveInputObserver = new LiveInputObserver();
@@ -62,6 +67,11 @@ public class EclipseRepl implements IRepl {
     @Override
     public ICommandInvoker getInvoker() {
         return this.invoker;
+    }
+
+    @Override
+    public IEditorServices getServices() {
+        return services;
     }
 
     /**

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
@@ -29,10 +29,14 @@ import rx.Observer;
  *
  * Note that this class evaluates input in a separate thread.
  */
-public class EclipseRepl implements IRepl, Observer<String> {
+public class EclipseRepl implements IRepl {
     private final IDisplay display;
+    private final EclipseEditor editor; //NOPMD - Will be used in later commits.
     private final ICommandInvoker invoker;
     private final ExecutorService pool;
+
+    private final Observer<String> lineInputObserver;
+    private final Observer<String> liveInputObserver;
 
     /**
      * Instantiates a new EclipseRepl.
@@ -41,12 +45,18 @@ public class EclipseRepl implements IRepl, Observer<String> {
      *            The {@link ICommandInvoker} for executing user input.
      * @param display
      *            The {@link IDisplay} to send results to.
+     * @param editor
+     *            The {@link EclipseEditor} to send input results to.
      */
     @AssistedInject
-    public EclipseRepl(ICommandInvoker invoker, @Assisted IDisplay display) {
+	public EclipseRepl(ICommandInvoker invoker, @Assisted IDisplay display,
+			@Assisted EclipseEditor editor) {
         this.display = display;
+        this.editor = editor;
         this.invoker = invoker;
         pool = Executors.newSingleThreadExecutor();
+        this.lineInputObserver = new LineInputObserver();
+        this.liveInputObserver = new LiveInputObserver();
     }
 
     @Override
@@ -54,25 +64,22 @@ public class EclipseRepl implements IRepl, Observer<String> {
         return this.invoker;
     }
 
-    @Override
-    public void onCompleted() {
-        // We don't ever call onCompleted ourselves, so if it's called it is unexpectedly and
-        // probably an error somewhere. The pipeline cannot be restored, either.
-        System.err
-            .println("The observer/observable pipeline has completed unexpectedly."
-                     + "There is nothing more to do, try restarting the REPL.");
+    /**
+     * The line observer.
+     *
+     * @return {@link Observer} for input strings.
+     */
+    public Observer<String> getLineInputObserver() {
+		return this.lineInputObserver;
     }
 
-    @Override
-    public void onError(Throwable t) {
-        // Do not display this to the user, as it is an internal exception.
-        t.printStackTrace();
-    }
-
-    @Override
-    public void onNext(String input) {
-        appendInputToDisplay(input);
-        runAsJob(input);
+    /**
+     * The live observer.
+     *
+     * @return {@link Observer} for input strings.
+     */
+    public Observer<String> getLiveInputObserver() {
+		return this.liveInputObserver;
     }
 
     private void appendInputToDisplay(String input) {
@@ -114,4 +121,49 @@ public class EclipseRepl implements IRepl, Observer<String> {
         job.schedule();
     }
 
+    /**
+     * Abstract observer class implementing common behaviour for both observers.
+     */
+    private abstract static class InputObserver implements Observer<String> {
+
+		@Override
+		public final void onCompleted() {
+	        // We don't ever call onCompleted ourselves, so if it's called it is unexpectedly and
+	        // probably an error somewhere. The pipeline cannot be restored, either.
+	        System.err
+	            .println("The observer/observable pipeline has completed unexpectedly."
+	                     + "There is nothing more to do, try restarting the REPL.");
+		}
+
+		@Override
+		public final void onError(Throwable t) {
+	        // Do not display this to the user, as it is an internal exception.
+	        t.printStackTrace();
+		}
+
+    }
+
+    /**
+     * Line observer to be notified when the user presses enter.
+     */
+    private class LineInputObserver extends InputObserver {
+
+		@Override
+		public void onNext(String input) {
+	        appendInputToDisplay(input);
+	        runAsJob(input);
+		}
+
+    }
+
+    /**
+     * Live observer to be notified when input is being typed.
+     */
+    private class LiveInputObserver extends InputObserver {
+
+		@Override
+		public void onNext(String input) {
+		}
+
+    }
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/IWidgetFactory.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/IWidgetFactory.java
@@ -29,12 +29,14 @@ public interface IWidgetFactory {
     EclipseEditor createEditor(Composite parent);
 
     /**
-     * Instantiate a new {@link EclipseRepl}.
-     *
-     * @param display
-     *            The {@link IDisplay} for displaying results.
-     * @return The created {@link EclipseRepl}.
-     */
-    EclipseRepl createRepl(IDisplay display);
+	 * Instantiate a new {@link EclipseRepl}.
+	 *
+	 * @param display
+	 *            The {@link IDisplay} for displaying results.
+	 * @param editor
+	 *            The {@link EclipseEditor}.
+	 * @return The created {@link EclipseRepl}.
+	 */
+	EclipseRepl createRepl(IDisplay display, EclipseEditor editor);
 
 }


### PR DESCRIPTION
Implements an architecture design for the Editor Servicese.

- Editor services is an object that `IRepl` uses to request specific `FailOrSuccessResults<>` of some service result.
- The Services interface directly with `FailableFunctions`.
- The functions are composed by `FunctionComposer`, which is a similar factory/builder to `CommandBuilder<B>`. The Functioncomposer takes over some responsibilities of the commandbuilder and decouples the function composition from the `IReplCommand`s.
- The Eclipse frontend implements code to enable to display of highlighted regions.
- The clients get a `FailOrSuccessVisitor`, which can only visit `FailOrSuccessResult`s (These are still visitable in the original way as well, as part of the `IResult` interface).
- The facilitate the dispatch of exceptions in the return (`ExceptionResult`), a third option to the FailOrSuccess data type was added. Whether this should stay is debatable, but currently it is safer to not break original behaviour.