### PR TITLE
Replace old build status button with new CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spoofax shell [![Build Status](https://travis-ci.org/spoofax-shell/spoofax-shell.svg?branch=master)](https://travis-ci.org/spoofax-shell/spoofax-shell)
+# Spoofax shell [![Build Status](https://travis-ci.org/spoofax-shell-2017/spoofax-shell.svg?branch=master)](https://travis-ci.org/spoofax-shell-2017/spoofax-shell)
 
 TU Delft TI3806 Bachelor end project. Please see [CONTRIBUTING.md](https://github.com/spoofax-shell/spoofax-shell/blob/master/CONTRIBUTING.md)
 before opening issues or submitting pull requests.


### PR DESCRIPTION
The Readme still contained the previous year's Travis CI status button.